### PR TITLE
allow override bootloader

### DIFF
--- a/modules/system/boot/loader/raspberrypi/default.nix
+++ b/modules/system/boot/loader/raspberrypi/default.nix
@@ -250,7 +250,7 @@ in
       boot.loader.grub.enable = false;
 
       system = {
-        build.installBootLoader = builder.${cfg.bootloader};
+        build.installBootLoader = lib.mkOverride 60 (builder.${cfg.bootloader});
         boot.loader.id = "raspberrypi";
         boot.loader.kernelFile = pkgs.stdenv.hostPlatform.linux-kernel.target;
       };


### PR DESCRIPTION
```
error: The option `system.build.installBootLoader' is defined multiple times while it's expected to be unique.
       Only one bootloader can be enabled at a time. This requirement has not
       been checked until NixOS 22.05. Earlier versions defaulted to the last
       definition. Change your configuration to enable only one bootloader.

       Definition values:
       - In `/nix/store/mvnfzv7y69lbr56vdhrhdqkv5b7qhsr2-source/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix': <derivation install-systemd-boot.sh>
       - In `/nix/store/ha19ys6xwln2qpwg7j6466ky27s2afh7-source/modules/system/boot/loader/raspberrypi': "/nix/store/vjrf75p5kminx2156a0x39ikwwax1lzr-kernelboot-builder.sh -f /boot/firmware -c"
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```

I needed to do this in order to override the default bootloader:
```
boot.loader.raspberryPi.bootloader = lib.mkForce "kernelboot";
```