### PR TITLE
Patch nixpkgs instead of using a fork

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,20 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz?rev=ff81ac966bb2cae68946d5ed5fc4994f96d0ffec&revCount=69"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
     "nixos-images": {
       "inputs": {
         "nixos-stable": [
@@ -42,16 +56,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755350418,
-        "narHash": "sha256-YSMmJZYzOYpb+orAb3/7FHAQRz7MTl59MG8202xt+sM=",
-        "owner": "nvmd",
+        "lastModified": 1755186698,
+        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a3b5145a3a21e638ac847e686ca8cfc33fae620",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
         "type": "github"
       },
       "original": {
-        "owner": "nvmd",
-        "ref": "modules-with-keys-25.05",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -59,6 +73,7 @@
     "root": {
       "inputs": {
         "argononed": "argononed",
+        "flake-compat": "flake-compat",
         "nixos-images": "nixos-images",
         "nixpkgs": "nixpkgs"
       }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,22 +1,25 @@
-{ lib, self, ... }:
+{ self, ... }:
 
 let
+  patchedNixpkgs = import ./patched-nixpkgs.nix {inherit self;};
+  lib = patchedNixpkgs.lib;
+
   # use makeScope instead?
   flib = lib.makeExtensible (flib_self: let
-    callLibs = file: import file { flib = flib_self; inherit self lib; };
+    callLibs = file: import file { flib = flib_self; inherit self patchedNixpkgs; };
   in {
 
   # NOTE: Endusers: please avoid using `int` (`internal`) directly
   int = callLibs ./internal.nix;
 
-  nixosSystem = { nixpkgs ? self.inputs.nixpkgs
+  nixosSystem = { nixpkgs ? patchedNixpkgs
                 , trustCaches ? true
                 , ...
                 }@args: flib.int.nixosSystemRPi {
     inherit nixpkgs trustCaches;
     rpiModules = [ flib.int.default-nixos-raspberrypi-config ];
   } args;
-  nixosSystemFull = { nixpkgs ? self.inputs.nixpkgs
+  nixosSystemFull = { nixpkgs ? patchedNixpkgs
                     , trustCaches ? true
                     , ...
                     }@args: flib.int.nixosSystemRPi {
@@ -24,7 +27,7 @@ let
     rpiModules = [ flib.int.full-nixos-raspberrypi-config ];
   } args;
 
-  nixosInstaller = { nixpkgs ? self.inputs.nixpkgs
+  nixosInstaller = { nixpkgs ? patchedNixpkgs
                    , trustCaches ? true
                    , ...
                    }@args: flib.int.nixosSystemRPi {

--- a/lib/internal.nix
+++ b/lib/internal.nix
@@ -1,8 +1,6 @@
-{ lib, self, ... }:
-
-{
+{ patchedNixpkgs, self, ... }: {
   nixosSystemRPi =
-    { nixpkgs ? self.inputs.nixpkgs
+    { nixpkgs ? patchedNixpkgs
     , trustCaches ? true
     , rpiModules
     }:
@@ -14,7 +12,7 @@
         modules = rpiModules
           # Nix cache with prebuilt packages,
           # see `devshells/nix-build-to-cachix.nix` for a list
-          ++ lib.optional trustCaches self.nixosModules.trusted-nix-caches
+          ++ nixpkgs.lib.optional trustCaches self.nixosModules.trusted-nix-caches
           # User modules
           ++ args.modules;
     });

--- a/lib/patched-nixpkgs.nix
+++ b/lib/patched-nixpkgs.nix
@@ -1,0 +1,20 @@
+{self, system ? builtins.currentSystem, ...}: let
+  pre-pkgs = self.inputs.nixpkgs.legacyPackages."${system}";
+
+  patchedSrc = pre-pkgs.applyPatches
+    {
+      name = "nixpkgs";
+      src = self.inputs.nixpkgs.outPath;
+      patches = [
+        (
+          pre-pkgs.fetchpatch {
+            name = "pr-398456";
+            url = "https://patch-diff.githubusercontent.com/raw/NixOS/nixpkgs/pull/398456.patch";
+            sha256 = "sha256-N4gry4cH0UqumhTmOH6jyHNWpvW11eRDlGsnj5uSi+0=";
+          }
+        )
+      ];
+    };
+in
+  (import self.inputs.flake-compat { src = patchedSrc; }).outputs
+

--- a/lib/patched-nixpkgs.nix
+++ b/lib/patched-nixpkgs.nix
@@ -1,7 +1,8 @@
-{self, system ? builtins.currentSystem, ...}: let
-  pre-pkgs = self.inputs.nixpkgs.legacyPackages."${system}";
+{self, ...}: let
+  pre-pkgs = import self.inputs.nixpkgs {};
 
-  patchedSrc = pre-pkgs.applyPatches
+  patchedSrc =
+    pre-pkgs.applyPatches
     {
       name = "nixpkgs";
       src = self.inputs.nixpkgs.outPath;
@@ -16,5 +17,4 @@
       ];
     };
 in
-  (import self.inputs.flake-compat { src = patchedSrc; }).outputs
-
+  (import self.inputs.flake-compat {src = patchedSrc;}).outputs

--- a/overlays/vendor-firmware.nix
+++ b/overlays/vendor-firmware.nix
@@ -97,6 +97,7 @@ self: super: { # final: prev:
 
   raspberrypiWirelessFirmware_20250408 = super.raspberrypiWirelessFirmware.overrideAttrs (old: {
     version = "2025-04-08";
+    __intentionallyOverridingVersion = true; # silence warning regarding missing `src` attr.
     srcs = [
       # https://github.com/RPi-Distro/bluez-firmware/commits/bookworm
       # 1.2-9+rpt3 release – 20240226
@@ -120,6 +121,7 @@ self: super: { # final: prev:
 
   raspberrypiWirelessFirmware_20241223 = super.raspberrypiWirelessFirmware.overrideAttrs (old: {
     version = "2024-12-23";
+    __intentionallyOverridingVersion = true; # silence warning regarding missing `src` attr.
     srcs = [
       # https://github.com/RPi-Distro/bluez-firmware/commits/bookworm
       # 1.2-9+rpt3 release – 20240226
@@ -145,6 +147,7 @@ self: super: { # final: prev:
   # pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
   raspberrypiWirelessFirmware_20240226 = super.raspberrypiWirelessFirmware.overrideAttrs (old: {
     version = "2024-02-26";
+    __intentionallyOverridingVersion = true; # silence warning regarding missing `src` attr.
     srcs = [
       # https://github.com/RPi-Distro/bluez-firmware/commits/bookworm
       # https://github.com/RPi-Distro/bluez-firmware/tree/78d6a07730e2d20c035899521ab67726dc028e1c
@@ -171,6 +174,7 @@ self: super: { # final: prev:
 
   raspberrypiWirelessFirmware_20240117 = super.raspberrypiWirelessFirmware.overrideAttrs (old: {
     version = "2024-01-17";
+    __intentionallyOverridingVersion = true; # silence warning regarding missing `src` attr.
     srcs = [
       # as in nixpkgs-unstable
       # https://github.com/RPi-Distro/bluez-firmware/commits/bookworm
@@ -198,6 +202,7 @@ self: super: { # final: prev:
   # as in nixpkgs-unstable
   raspberrypiWirelessFirmware_20231115 = super.raspberrypiWirelessFirmware.overrideAttrs (old: {
     version = "unstable-2023-11-15";
+    __intentionallyOverridingVersion = true; # silence warning regarding missing `src` attr.
     srcs = [
       (super.fetchFromGitHub {  # 1.2-9+rpt2 release – 20231024
         name = "bluez-firmware";


### PR DESCRIPTION
Hi,
I'd like to propose to remove the dependency to a nixpkgs fork via this PR. I stumbled upon [this](https://blog.bhasher.com/posts/patching-flake-inputs-with-pull-requests/) article just recently. It didn't work, but it was a good starting point for this PR.

The important part is [lib/patched-nixpkgs.nix](https://github.com/nvmd/nixos-raspberrypi/compare/develop...nevesenin:nixos-raspberrypi:patch-nixpkgs?expand=1#diff-fa3f0d859ccadbc86ce6459cb3aef94ee374136af6336cd540e1a84bd830ebf4).

It's a draft by now, because I don't know how you would like to have things organized, so take it as a showcase for now. I'd love to know your opinion on that. 