### PR TITLE
linux-rpi: 6.12.44

### DIFF
--- a/overlays/kernels.nix
+++ b/overlays/kernels.nix
@@ -51,6 +51,13 @@ let
 
   # Linux
 
+  linux_v6_12_44_argsOverride = {
+    modDirVersion = "6.12.44";
+    tag = "unstable_20250829";
+    rev = "6c61955254d5c1af6687e79b1de4db7e76c9ff68"; # 6.12.44
+    srcHash = "sha256-5v28FioaPYSV6HYGiJn4X+PZ7byOPDCVKZfU0JukV3A=";
+  };
+
   linux_v6_12_34_argsOverride = {
     # https://github.com/raspberrypi/linux/releases/tag/stable_20250702
     modDirVersion = "6.12.34";
@@ -212,6 +219,7 @@ let
     ];
   };
 in {
+  "6_12_44" = linux_v6_12_44_argsOverride;
   "6_12_34" = linux_v6_12_34_argsOverride;
   "6_12_25" = linux_v6_12_25_argsOverride;
   "6_6_74" = linux_v6_6_74_argsOverride;

--- a/overlays/linux-and-firmware.nix
+++ b/overlays/linux-and-firmware.nix
@@ -29,7 +29,12 @@ in self: super: {
 
     { default = self.linuxAndFirmware.v6_12_25; }
 
-    { latest = self.linuxAndFirmware.v6_12_25; }
+    { latest = self.linuxAndFirmware.v6_12_44; }
+
+    (mkBundle self "v6_12_44" {
+      fw = self.raspberrypifw_20250829;
+      wFw = self.raspberrypiWirelessFirmware_20250408;
+    })
 
     (mkBundle self "v6_12_34" {
       fw = self.raspberrypifw_20250702;

--- a/overlays/vendor-firmware.nix
+++ b/overlays/vendor-firmware.nix
@@ -4,8 +4,21 @@ self: super: { # final: prev:
   # pkgs/os-specific/linux/firmware/raspberrypi/default.nix
   # https://github.com/raspberrypi/firmware/commits/stable/
 
+  # see `extra/git_hash` for a matching hash of the `raspberrypi/linux`
+
+
+  raspberrypifw_20250829 = super.raspberrypifw.overrideAttrs (old: {
+    # this release is untagged in the upstream for linux 6.12.44
+    version = "unstable_20250829";
+    src = super.fetchFromGitHub {
+      owner = "raspberrypi";
+      repo = "firmware";
+      rev = "73065c21a0337eac9de13521fc1254cdadd3bd0a";
+      hash = "sha256-cprLY/xtYuE2LjgbQGuPlHBlIYLS5YSp/URvgCLMB14=";
+    };
+  });
+
   raspberrypifw_20250702 = super.raspberrypifw.overrideAttrs (old: {
-    # see `extra/git_hash` for a matching hash of the `raspberrypi/linux`
     # this release is untagged in the upstream
     # this the the version of the matching stable kernel from `raspberrypi/linux`
     version = "1.20250702";

--- a/overlays/vendor-kernel.nix
+++ b/overlays/vendor-kernel.nix
@@ -50,6 +50,7 @@ let
 
 in self: super: super.lib.mergeAttrsList (
   builtins.concatLists [
+    (mkLinuxFor super "6_12_44" [ "02" "3" "4" "5" ])
     (mkLinuxFor super "6_12_34" [ "02" "3" "4" "5" ])
     (mkLinuxFor super "6_12_25" [ "02" "3" "4" "5" ])
     (mkLinuxFor super "6_6_74" [ "02" "4" "5" ])


### PR DESCRIPTION
Add Raspberry's vendor `linux_rpi` 6.12.44 and aligned `raspberrypifw` firmware:
- https://github.com/raspberrypi/linux/commit/6c61955254d5c1af6687e79b1de4db7e76c9ff68
- https://github.com/raspberrypi/firmware/commit/73065c21a0337eac9de13521fc1254cdadd3bd0a

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nvmd/nixos-raspberrypi/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc