### PR TITLE
Optional customizations for systems with 16k memory page size (rpi5/bcm2712)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ nixosConfigurations.rpi5-demo = nixos-raspberrypi.lib.nixosSystem {
       # list of modules
       imports = with nixos-raspberrypi.nixosModules; [
         raspberry-pi-5.base
+        raspberry-pi-5.page-size-16k
         raspberry-pi-5.display-vc4
         raspberry-pi-5.bluetooth
       ];
@@ -121,6 +122,7 @@ imports = with nixos-raspberrypi.nixosModules; [
   raspberry-pi-4.display-vc4
 
   # RPi5:
+  raspberry-pi-5.page-size-16k  # Recommended: optimizations and fixes for issues arising from 16k memory page size (only for systems running default rpi5 (bcm2712) kernel)
   # use one of following for the "PrimaryGPU" configuration:
   raspberry-pi-5.display-vc4  # "regular" display connected
   raspberry-pi-5.display-rp1  # for RP1-connected (DPI/composite/MIPI DSI) display

--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,7 @@
         display-vc4 = import ./modules/display-vc4.nix;
         display-rp1 = import ./modules/raspberry-pi-5/display-rp1.nix;
         bluetooth = import ./modules/bluetooth.nix;
+        page-size-16k = import ./modules/raspberry-pi-5/page-size-16k.nix;
       };
 
       raspberry-pi-4 = {
@@ -130,6 +131,7 @@
 
       pkgs = import ./overlays/pkgs.nix;
       vendor-pkgs = import ./overlays/vendor-pkgs.nix;
+      jemalloc-page-size-16k = import ./overlays/jemalloc-page-size-16k.nix;
 
       vendor-firmware = import ./overlays/vendor-firmware.nix;
       vendor-kernel = import ./overlays/vendor-kernel.nix;
@@ -276,6 +278,7 @@
           imports = with nixos-raspberrypi.nixosModules; [
             # Hardware configuration
             raspberry-pi-5.base
+            raspberry-pi-5.page-size-16k
           ];
         })
         custom-user-config

--- a/modules/raspberry-pi-5/page-size-16k.nix
+++ b/modules/raspberry-pi-5/page-size-16k.nix
@@ -1,0 +1,10 @@
+{ self, lib, ... }:
+{
+  # Optimizations or fixes for systems running
+  # rpi5 (bcm2712-configured) Linux kernel 
+  # See also: https://github.com/nvmd/nixos-raspberrypi/issues/64
+  
+  nixpkgs.overlays = lib.mkBefore [
+    self.overlays.jemalloc-page-size-16k
+  ];
+}

--- a/overlays/jemalloc-page-size-16k.nix
+++ b/overlays/jemalloc-page-size-16k.nix
@@ -1,0 +1,12 @@
+final: prev: {
+  # https://github.com/nvmd/nixos-raspberrypi/issues/64
+  # credit for the initial version of this snippet goes to @micahcc
+  jemalloc = prev.jemalloc.overrideAttrs (old: {
+    # --with-lg-page=(log2 page_size)
+    # RPi5 (bcm2712): since our page size is 16384 (2**14), we need 14
+    configureFlags = let
+      pageSizeFlag = "--with-lg-page";
+    in (prev.lib.filter (flag: prev.lib.hasPrefix pageSizeFlag flag == false) old.configureFlags)
+      ++ [ "${pageSizeFlag}=14" ];
+  });
+}


### PR DESCRIPTION
This PR introduces `raspberry-pi-5.page-size-16k` module.
The idea is to provide a single entry point for enabling optimizations and fixes concerning 16k memory page size, which are not present in `nixpkgs`.

So far it includes a single overlay for fixing `jemalloc` behavior, see #64. Thanks for @micahcc for providing the initial version for the snippet and bringing up the 16k memory page issue in general, as well as sharing some further insights.

The module is optional, but recommended for RPi5 systems running `rpi5` Linux kernel (i.e. configured with `bcm2712` config, which is the default behavior for RPi5 systems configured with this flake).

The current plan is to provide the cache for the RPi5 systems with this module enabled by default.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nvmd/nixos-raspberrypi/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc