### PR TITLE
libpisp: make libpisp overlay optional

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,8 @@
       vendor-kernel = import ./overlays/vendor-kernel.nix;
 
       kernel-and-firmware = import ./overlays/linux-and-firmware.nix;
+
+      libpisp-default-config-path = import ./overlays/libpisp-default-config-path.nix;
     };
 
     # "RPi world": nixpkgs with all overlays applied "globally", i.e.

--- a/overlays/libpisp-default-config-path.nix
+++ b/overlays/libpisp-default-config-path.nix
@@ -1,0 +1,21 @@
+self: super: {
+  # Fixes the issue https://github.com/nvmd/nixos-raspberrypi/issues/48
+
+  # This overlay is to be removed once https://github.com/NixOS/nixpkgs/pull/429288
+  # is upstreamed
+  libpisp = super.libpisp.overrideAttrs (old: {
+    preFixup = ''
+      so=$out/lib/libpisp.so.1
+      patchelf --set-soname $so $so
+      patchelf --remove-rpath $so
+      needed=$(patchelf --print-needed $so)
+      for pkg in ${super.glibc} ${super.boost} ${super.libgcc} ${super.stdenv.cc.cc.lib}; do
+        for lib in $needed; do
+          for libpath in $(find -L $pkg/lib -type f -name "$lib"); do
+            patchelf --replace-needed $lib $libpath $so
+          done
+        done
+      done
+    '';
+  });
+}

--- a/overlays/vendor-pkgs.nix
+++ b/overlays/vendor-pkgs.nix
@@ -1,22 +1,5 @@
 self: super: { # final: prev:
 
-  # now available from nixpkgs but waiting on https://github.com/NixOS/nixpkgs/pull/429288
-  libpisp = super.libpisp.overrideAttrs (old: {
-    preFixup = ''
-      so=$out/lib/libpisp.so.1
-      patchelf --set-soname $so $so
-      patchelf --remove-rpath $so
-      needed=$(patchelf --print-needed $so)
-      for pkg in ${super.glibc} ${super.boost} ${super.libgcc} ${super.stdenv.cc.cc.lib}; do
-        for lib in $needed; do
-          for libpath in $(find -L $pkg/lib -type f -name "$lib"); do
-            patchelf --replace-needed $lib $libpath $so
-          done
-        done
-      done
-    '';
-  });
-
   libraspberrypi = super.callPackage ../pkgs/raspberrypi/libraspberrypi.nix {};
 
   raspberrypi-userland = self.libraspberrypi;


### PR DESCRIPTION
Move `libpisp` overlay introduced in #55 from the `vendor-pkgs` to its own optional `libpisp-default-config-path` overlay to avoids massive rebuild as reported in #85.

#48 seems to be a relatively niche problem, while requiring lots of resources to maintain in the scope of this project. Should be fine to make the overlay optional.
Waiting for NixOS/nixpkgs#429288 to be accepted in some form.


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nvmd/nixos-raspberrypi/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc