### PR TITLE
linux-rpi: replace `lib.overrideDerivation` with `overrideAttrs`

### DIFF
--- a/pkgs/linux-rpi.nix
+++ b/pkgs/linux-rpi.nix
@@ -44,7 +44,7 @@ let
     };
   }.${arch}.${rpiModel};
 in
-lib.overrideDerivation (buildLinux (args // rec {
+(buildLinux (args // rec {
   version = "${modDirVersion}-${tag}";
   inherit modDirVersion;
   pname = "linux_rpi-${builtins.elemAt (lib.splitString "_" defconfig) 0}";
@@ -74,7 +74,7 @@ lib.overrideDerivation (buildLinux (args // rec {
 
   ignoreConfigErrors = true;
 
-} // (args.argsOverride or {}))) (oldAttrs: {
+} // (args.argsOverride or {}))).overrideAttrs {
   postConfigure = ''
     # The v7 defconfig has this set to '-v7' which screws up our modDirVersion.
     sed -i $buildRoot/.config -e 's/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION=""/'
@@ -101,4 +101,4 @@ lib.overrideDerivation (buildLinux (args // rec {
     overlaySrcDir="$srcs/arch/${armArch}/boot/dts/overlays"
     cp "$overlaySrcDir/README" "$out/dtbs/overlays/"
   '';
-})
+}


### PR DESCRIPTION
I wanted to set up Amnezia VPN on my Pi by adding appropriate configuration using [`networking.wg-quick`](https://search.nixos.org/options?channel=unstable&show=networking.wg-quick.interfaces.%3Cname%3E.type&query=wg-quick). That automatically adds the [`amneziawg` kernel module](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/os-specific/linux/amneziawg/default.nix). But then `nixos-rebuild switch` failed with this evaluation error:

```
evaluation warning: srcOnly: derivations not created by a variant of stdenv.mkDerivation are not supported. Code relying on behaviour of srcOnly with non-stdenv derivations may break in the future.
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nixos-system-snejugal-pi-25.11.20250906.872cf06'
         whose name attribute is located at /nix/store/ifscc9imnkxpaj1jpqxif1hram0fi2qy-source/pkgs/stdenv/generic/make-derivation.nix:538:13

       … while evaluating attribute 'buildCommand' of derivation 'nixos-system-snejugal-pi-25.11.20250906.872cf06'
         at /nix/store/ifscc9imnkxpaj1jpqxif1hram0fi2qy-source/nixos/modules/system/activation/top-level.nix:68:7:
           67|       passAsFile = [ "extraDependencies" ];
           68|       buildCommand = systemBuilder;
             |       ^
           69|

       … while evaluating the option `system.systemBuilderCommands':

       … while evaluating definitions from `/nix/store/ifscc9imnkxpaj1jpqxif1hram0fi2qy-source/nixos/modules/system/boot/kernel.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: The `env` attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping:
         - KRUSTFLAGS: in `env`: "--remap-path-prefix /nix/store/6pl5vrshqfl1yhikn54vnj1kjq5a43jh-rust-lib-src=/"; in derivation arguments: "--remap-path-prefix /nix/store/6pl5vrshqfl1yhikn54vnj1kjq5a43jh-rust-lib-src=/"
         - RUST_LIB_SRC: in `env`: <derivation rust-lib-src>; in derivation arguments: <derivation rust-lib-src>
```

Since the same configuration worked just fine on my laptop, I figured that it has to do something with `nixos-raspberrypi`. Indeed, `amneziawg` (for some reasons) uses `srcOnly` on the kernel:

https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/os-specific/linux/amneziawg/default.nix#L34

and `srcOnly` tries to use `overrideAttrs` if possible, but if not emits a warning and tries to work around its absence:

https://github.com/NixOS/nixpkgs/blob/d2e44cca6b32a8e1e90b3227f11f41184b0bdf46/pkgs/build-support/src-only/default.nix#L68-L84

and this workaround seems to fail sometimes, just like in my case. But why would there be no `overrideAttrs`? I then searched where the kernel for the Pi is built and found it in `pkgs/linux-rpi.nix`. It uses `lib.overrideDerivation`, and I'm not really into all the differences, but the manual tells to use `overrideAttrs` instead whenever possible. The override didn't seem to me to be doing something that wouldn't be possible with `overrideAttrs`. So I tried to use it instead and the resulting derivation seemed to not change at all as `nixos-rebuild switch` without VPN configuration did not do anything. Yet with `amneziawg` enabled, it built just fine without the warning and error from above.

Overall it seems that there's no point in using `lib.overrideDerivation` over `overrideAttrs`, yet it prevents some custom kernel modules to be evaluated since it does not seem to provide `overrideAttrs` automatically. So in this PR I replaced it with `overrideAttrs`.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nvmd/nixos-raspberrypi/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc