### PR TITLE
ci: build packages and nixos configurations using GitHub Action

### DIFF
--- a/.github/workflows/cachix.yaml
+++ b/.github/workflows/cachix.yaml
@@ -1,0 +1,98 @@
+name: Build and Push to cachix
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build-raspberrypi-kernels:
+    strategy:
+      # Continue with the remaining packages if one fails
+      fail-fast: false
+
+      matrix:
+        # ~1.5 hours per job—well under the 6-hour per-job time limit.
+        version: ["02", "3", "4", "5"]
+
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v14
+        with:
+          name: "${{ secrets.CACHIX_CACHE_NAME }}"
+          # # if you chose signing key for write access
+          # signingkey: "${{ secrets.cachix_signing_key }}"
+          # # if you chose api tokens for write access or if you have a private cache
+          authtoken: ${{ secrets.cachix_auth_token }}
+      - run: nix --accept-flake-config build .#packages.aarch64-linux.linux_rpi${{ matrix.version }}
+      - run: nix --accept-flake-config build .#nixosConfigurations.rpi${{ matrix.version }}-installer.config.system.build.toplevel
+
+  build-vendor-packages-1:
+    strategy:
+      # Continue with the remaining packages if one fails
+      fail-fast: false
+
+      matrix:
+        package:
+          - raspberrypifw # ~1 minutes
+          - raspberrypiWirelessFirmware # ~1 minutes
+          - raspberrypi-utils # ~1 minutes
+          - raspberrypi-udev-rules # ~1 minutes
+
+          # - pisugar3-kmod
+          # - pisugar2-kmod
+          - pisugar-power-manager-rs # ~3 minutes
+
+          - ffmpeg_7-headless # ~5 minutes
+
+          # - kodi
+          - kodi-gbm # ~40 minutes
+          # - kodi-wayland
+
+          - rpicam-apps # ~3 minutes
+          - libcamera # ~3 minutes
+          - libpisp # ~1 minutes
+          # - libraspberrypi
+
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v14
+        with:
+          name: "${{ secrets.CACHIX_CACHE_NAME }}"
+          # # if you chose signing key for write access
+          # signingkey: "${{ secrets.cachix_signing_key }}"
+          # # if you chose api tokens for write access or if you have a private cache
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix --accept-flake-config build .#packages.aarch64-linux.${{ matrix.package }}
+
+  build-vendor-packages-2:
+    needs: build-vendor-packages-1
+
+    strategy:
+      # Continue with the remaining packages if one fails
+      fail-fast: false
+
+      matrix:
+        package:
+          # Depends on ffmpeg-headless. Avoid concurrent builds to prevent OOM errors.
+          - ffmpeg_7
+          - vlc
+
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v14
+        with:
+          name: "${{ secrets.CACHIX_CACHE_NAME }}"
+          # # if you chose signing key for write access
+          # signingkey: "${{ secrets.cachix_signing_key }}"
+          # # if you chose api tokens for write access or if you have a private cache
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix --accept-flake-config build .#packages.aarch64-linux.${{ matrix.package }}


### PR DESCRIPTION
TLDR: This pull request adds a new GitHub Actions workflow that builds packages and pushes artifacts to Cachix. It automates what `devshells/nix-build-to-cachix.nix` previously handled.

close #96 

## Design

### Workflow

A new file, `.github/workflows/cachix.yaml`, defines a multi-job workflow that organizes builds to balance wall-clock time and runner utilization:

- **Kernel builds**: Build multiple Raspberry Pi kernel versions in parallel.
- **Vendor package builds**: Split vendor packages into two jobs to better respect dependency ordering and reduce resource contention.
  - This introduces some complexity. If you prefer a simpler setup, we can merge them into a single job; you’d then rerun the job once `ffmpeg_7-headless` is available in Cachix (expected to be rare).
- **Cachix integration** — Push build results to Cachix for reuse across runs and machines.

### Required Secrets

Please add the following repository secrets
(*Repo Settings → Security → Secrets and variables → Actions → New repository secret*):

- `CACHIX_CACHE_NAME`: `nixos-raspberrypi`
- `CACHIX_AUTH_TOKEN`: a token generated in Cachix
  (*Cachix → Cache Settings → Auth Tokens → Generate*)

Links for convenience:

- GitHub secrets: [https://github.com/nvmd/nixos-raspberrypi/settings/secrets/actions](https://github.com/nvmd/nixos-raspberrypi/settings/secrets/actions)
- Cachix tokens: [https://app.cachix.org/cache/nixos-raspberrypi/settings/authtokens](https://app.cachix.org/cache/nixos-raspberrypi/settings/authtokens)

## Testing

I successfully ran the jobs in my forked repository: <https://github.com/yzx9/nixos-raspberrypi/actions/runs/18270405302/job/52011788319>.

Because we don’t enable the `on.pull_request` trigger (it’s unsafe for untrusted forks), you’ll need to fork my repository and configure the required secrets to run the GitHub Action.

Since these packages are already present in `nixos-raspberrypi.cachix.org`, the builds will be skipped and the workflow will finish in about 3 minutes. To perform a full rebuild, you have two options:

1. Use a fresh cache, remove the `--accept-flake-config` option to prevent pulling from `nixos-raspberrypi.cachix.org`.
2. (not recommended) Clear the cache `nixos-raspberrypi.cachix.org`.


## GitHub Action Usage

- Cost: GitHub Actions usage on standard GitHub-hosted runners is [free for public repositories](https://docs.github.com/en/billing/concepts/product-billing/github-actions).
- [Runtime limits](https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories):
    - Each job on GitHub-hosted runners: 6 hours max.
    - Entire workflow run: 35 days max (includes waits/approvals).
    - Storage & minutes: public repositories using standard GitHub-hosted runners are not charged and don’t consume a private-account quota.
    - Job queue time (self‑hosted): 24 hours.


