### PR TITLE
flake: add flake-compat for non-flake users

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,12 @@
+(import (
+  let
+    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    nodeName = lock.nodes.root.inputs.flake-compat;
+  in
+  fetchTarball {
+    url =
+      lock.nodes.${nodeName}.locked.url
+        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
+    sha256 = lock.nodes.${nodeName}.locked.narHash;
+  }
+) { src = ./.; }).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,21 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "nixos-images": {
       "inputs": {
         "nixos-stable": [
@@ -59,6 +74,7 @@
     "root": {
       "inputs": {
         "argononed": "argononed",
+        "flake-compat": "flake-compat",
         "nixos-images": "nixos-images",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,8 @@
       inputs.nixos-stable.follows = "nixpkgs";
       inputs.nixos-unstable.follows = "nixpkgs";
     };
+
+    flake-compat.url = "github:edolstra/flake-compat";
   };
 
   outputs = { self, nixpkgs, argononed, nixos-images, ... }@inputs: let


### PR DESCRIPTION
I'd like to use this project without flakes, but this project ends up pretty tied to the flake (e.g. because of the proliferous usage of `self`). This probably *could* be rewritten to be compatible with both, but that'd be a bit of a pain and probably messier. [edolstra/flake-compat](https://github.com/edolstra/flake-compat) allows a way for non-flake users to use the flake without any real issue here, and so I'd like to propose adding it to this project.

For an example of usage, I use `npins`, and so using this in my NixOS configurations looks like:
```nix
let
  pins = import ../../npins;
  nixos-raspberrypi = import pins.nixos-raspberrypi;
in
{
  imports = [
    nixos-raspberrypi.lib.inject-overlays
    nixos-raspberrypi.nixosModules.nixpkgs-rpi
    nixos-raspberrypi.nixosModules.raspberry-pi-5.base
    nixos-raspberrypi.nixosModules.raspberry-pi-5.display-vc4
    nixos-raspberrypi.nixosModules.usb-gadget-ethernet
  ];
  # --snip--
}
```
That is, the downstream experience for non-flake users is essentially the same as that of flake users.