### PR TITLE
'hostPlatform' has been renamed to/replaced by 'stdenv.hostPlatform'

### DIFF
--- a/modules/nixpkgs-rpi.nix
+++ b/modules/nixpkgs-rpi.nix
@@ -4,7 +4,7 @@
   nixpkgs.overlays = [
     (final: prev: {
       rpi = import self.inputs.nixpkgs {
-        inherit (prev) system;
+        inherit (prev.stdenv.hostPlatform) system;
         config = {
           inherit (prev.config) allowUnfree allowUnfreePredicate;
         };

--- a/modules/raspberry-pi-02.nix
+++ b/modules/raspberry-pi-02.nix
@@ -1,4 +1,4 @@
-{ self, config, lib, pkgs, ... }:
+{ self, lib, pkgs, ... }:
 
 {
   imports = [ ./raspberrypi.nix ];
@@ -6,8 +6,8 @@
   boot.loader.raspberryPi = {
     variant = "02";
     bootloader = lib.mkDefault "uboot";
-    firmwarePackage = lib.mkDefault self.packages.${pkgs.hostPlatform.system}.raspberrypifw;
+    firmwarePackage = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
   };
 
-  boot.kernelPackages = lib.mkDefault self.packages.${pkgs.hostPlatform.system}.linuxPackages_rpi02;
+  boot.kernelPackages = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi02;
 }

--- a/modules/raspberry-pi-3.nix
+++ b/modules/raspberry-pi-3.nix
@@ -6,8 +6,8 @@
   boot.loader.raspberryPi = {
     variant = "3";
     bootloader = lib.mkDefault "uboot";
-    firmwarePackage = lib.mkDefault self.packages.${pkgs.hostPlatform.system}.raspberrypifw;
+    firmwarePackage = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
   };
 
-  boot.kernelPackages = lib.mkDefault self.packages.${pkgs.hostPlatform.system}.linuxPackages_rpi3;
+  boot.kernelPackages = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi3;
 }

--- a/modules/raspberry-pi-4.nix
+++ b/modules/raspberry-pi-4.nix
@@ -1,4 +1,4 @@
-{ self, config, lib, pkgs, ... }:
+{ self, lib, pkgs, ... }:
 
 {
   imports = [ ./raspberrypi.nix ];
@@ -6,11 +6,11 @@
   boot.loader.raspberryPi = {
     variant = "4";
     bootloader = lib.mkDefault "uboot";
-    firmwarePackage = lib.mkDefault self.packages.${pkgs.hostPlatform.system}.raspberrypifw;
+    firmwarePackage = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
   };
 
-  boot.kernelPackages = lib.mkDefault self.packages.${pkgs.hostPlatform.system}.linuxPackages_rpi4;
+  boot.kernelPackages = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi4;
   boot.initrd.availableKernelModules = [
-    "nvme"  # cm4 may have nvme drive connected with pcie
+    "nvme" # cm4 may have nvme drive connected with pcie
   ];
 }

--- a/modules/raspberry-pi-5/default.nix
+++ b/modules/raspberry-pi-5/default.nix
@@ -1,4 +1,4 @@
-{ self, config, lib, pkgs, ... }:
+{ self, lib, pkgs, ... }:
 
 {
   imports = [ ../raspberrypi.nix ];
@@ -6,11 +6,11 @@
   boot.loader.raspberryPi = {
     variant = "5";
     bootloader = lib.mkDefault "kernelboot";
-    firmwarePackage = lib.mkDefault self.packages.${pkgs.hostPlatform.system}.raspberrypifw;
+    firmwarePackage = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
   };
 
-  boot.kernelPackages = lib.mkDefault self.packages.${pkgs.hostPlatform.system}.linuxPackages_rpi5;
+  boot.kernelPackages = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi5;
   boot.initrd.availableKernelModules = [
-    "nvme"  # nvme drive connected with pcie
+    "nvme" # nvme drive connected with pcie
   ];
 }


### PR DESCRIPTION
'hostPlatform' has been renamed to/replaced by 'stdenv.hostPlatform'.
we should use the stdenv.hostPlatform (it be future proof)

(@nvmd new pull - with the additional fix for nixpkgs-rpi module)