### PR TITLE
Fix some typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Design objectives:
 
 This project grew naturally out of the need to configure and extend rather great [tstat's raspberry pi support repository](https://github.com/tstat/raspberry-pi-nix), which we used for some time.
 
-Unfortunately it was virtually impossible to work with without reengineering the whole thing, so this Flake was born. Inability to use it non-interactively with `nixos-anywhere` was the biggest concern.
+Unfortunately it was virtually impossible to work with it without reengineering the whole thing, so this Flake was born. Inability to use it non-interactively with `nixos-anywhere` was the biggest concern.
 
 We found [`boot.loader.raspberryPi` options](https://search.nixos.org/options?channel=unstable&show=boot.loader.raspberryPi) to be much more idiomatic, easier to extend, and maintain.
 


### PR DESCRIPTION
Thanks for all the work here. I think I will switch to this once from the sunset https://github.com/nix-community/raspberry-pi-nix

Reading a README made me pause at the "possible/impossible". I believe this was a typo and you've meant impossible. While at it I also spotted one more much more innocent typo (ot -> of). I'm not a native speaker so please check if these makes sense.

Rest of the changes are just removals of trailing white-space - something I have automated in the editor. If you want me to revert those I can but I found people mostly tend to like to see these removed so I'm opening it as is.