### PR TITLE
End transition period to the new options' naming, switch to upstream nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,16 +57,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771867432,
-        "narHash": "sha256-KOb/xJgNRoUDD7y42/lh2a1+akUQ7OYuBdwX/CZevFY=",
-        "owner": "nvmd",
+        "lastModified": 1771714954,
+        "narHash": "sha256-nhZJPnBavtu40/L2aqpljrfUNb2rxmWTmSjK2c9UKds=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2597cb7e564b9004c9d3182afb29b37ae842411a",
+        "rev": "afbbf774e2087c3d734266c22f96fca2e78d3620",
         "type": "github"
       },
       "original": {
-        "owner": "nvmd",
-        "ref": "modules-with-keys-25.11",
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,11 +12,7 @@
   };
 
   inputs = {
-    # use fork to allow disabling modules introduced by mkRemovedOptionModule
-    # and similar functions
-    # see PR nixos:nixpkgs#398456 (https://github.com/NixOS/nixpkgs/pull/398456)
-    nixpkgs.url = "github:nvmd/nixpkgs/modules-with-keys-25.11";
-    # nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
 
     argononed = {
       # url = "git+file:../argononed?shallow=1";

--- a/modules/system/boot/loader/raspberrypi/default.nix
+++ b/modules/system/boot/loader/raspberrypi/default.nix
@@ -193,18 +193,6 @@ let
 in
 
 {
-  imports = [
-    (mkRenamedOptionModule [ "boot" "loader" "raspberryPi" ] [ "boot" "loader" "raspberry-pi" ])
-  ];
-
-  disabledModules = [
-    # the module has been remove in nixpkgs, but that shouldn't prevent us
-    # from using the now free (!) name for our module
-    # mkRemovedOptionModule in `"modulesPath + rename.nix"`, unfortunately,
-    # prevents us from doing so in upstream nixpkgs
-    { key = "removedOptionModule#boot_loader_raspberryPi"; }
-  ];
-
   options = {
 
     boot.loader.raspberry-pi = {


### PR DESCRIPTION
This PR ends transition period started with #129.

Once it's merged older `boot.loader.raspberryPi` options won't work anymore, but using vanilla upstream nixpkgs will be possible without any patches.

I'm planning to merge it in 2-3 weeks after the #129 is merged to give the existing users some time to migrate to the new naming (`boot.loader.raspberryPi` -> `boot.loader.raspberry-pi`).
The most impatient can also use the branch of this PR as a source for the flake.

Add a 👍 reaction if you've already migrated!

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nvmd/nixos-raspberrypi/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc