### PR TITLE
kernels: add 6.12.47 (stable_20250916)

### DIFF
--- a/overlays/kernels.nix
+++ b/overlays/kernels.nix
@@ -51,6 +51,13 @@ let
 
   # Linux
 
+  linux_v6_12_47_argsOverride = {
+    # https://github.com/raspberrypi/linux/releases/tag/stable_20250916
+    modDirVersion = "6.12.47";
+    tag = "stable_20250916";
+    srcHash = "sha256-HG8Oc04V2t54l0SOn4gKmNJWQUrZfjWusgKcWvx74H0=";
+  };
+
   linux_v6_12_44_argsOverride = {
     modDirVersion = "6.12.44";
     tag = "unstable_20250829";
@@ -219,6 +226,7 @@ let
     ];
   };
 in {
+  "6_12_47" = linux_v6_12_47_argsOverride;
   "6_12_44" = linux_v6_12_44_argsOverride;
   "6_12_34" = linux_v6_12_34_argsOverride;
   "6_12_25" = linux_v6_12_25_argsOverride;

--- a/overlays/linux-and-firmware.nix
+++ b/overlays/linux-and-firmware.nix
@@ -29,7 +29,12 @@ in self: super: {
 
     { default = self.linuxAndFirmware.v6_12_34; }
 
-    { latest = self.linuxAndFirmware.v6_12_44; }
+    { latest = self.linuxAndFirmware.v6_12_47; }
+
+    (mkBundle self "v6_12_47" {
+      fw = self.raspberrypifw_20250915;
+      wFw = self.raspberrypiWirelessFirmware_20251008;
+    })
 
     (mkBundle self "v6_12_44" {
       fw = self.raspberrypifw_20250829;

--- a/overlays/vendor-kernel.nix
+++ b/overlays/vendor-kernel.nix
@@ -50,6 +50,7 @@ let
 
 in self: super: super.lib.mergeAttrsList (
   builtins.concatLists [
+    (mkLinuxFor super "6_12_47" [ "02" "3" "4" "5" ])
     (mkLinuxFor super "6_12_44" [ "02" "3" "4" "5" ])
     (mkLinuxFor super "6_12_34" [ "02" "3" "4" "5" ])
     (mkLinuxFor super "6_12_25" [ "02" "3" "4" "5" ])


### PR DESCRIPTION
Adds the latest stable kernel from raspberrypi/linux. The `stable_20250916` tag ships kernel 6.12.47.