### PR TITLE
modules: get flake ref from specialArgs instead of wrapper lambdas

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,15 +73,10 @@
 
     nixosModules = {
       trusted-nix-caches = import ./modules/trusted-nix-caches.nix;
-      nixpkgs-rpi = { config, lib, pkgs, ... }: import ./modules/nixpkgs-rpi.nix {
-        inherit config lib pkgs self;
-      };
+      nixpkgs-rpi = import ./modules/nixpkgs-rpi.nix;
 
       bootloader = import ./modules/system/boot/loader/raspberrypi;
-      # default = import ./modules/raspberrypi.nix;
-      default = { config, lib, pkgs, ... }: import ./modules/raspberrypi.nix {
-        inherit config lib pkgs self;
-      };
+      default = import ./modules/raspberrypi.nix;
 
       sd-image = import ./modules/installer/sd-card/sd-image-raspberrypi.nix;
 
@@ -90,21 +85,15 @@
       usb-gadget-ethernet = import ./modules/usb-gadget-ethernet.nix;
 
       raspberry-pi-5 = {
-        base = { config, lib, pkgs, ... }: import ./modules/raspberry-pi-5 {
-          inherit config lib pkgs self;
-        };
+        base = import ./modules/raspberry-pi-5;
         display-vc4 = import ./modules/display-vc4.nix;
         display-rp1 = import ./modules/raspberry-pi-5/display-rp1.nix;
         bluetooth = import ./modules/bluetooth.nix;
-        page-size-16k = { config, lib, pkgs, ... }: import ./modules/raspberry-pi-5/page-size-16k.nix {
-          inherit config lib pkgs self;
-        };
+        page-size-16k = import ./modules/raspberry-pi-5/page-size-16k.nix;
       };
 
       raspberry-pi-4 = {
-        base = { config, lib, pkgs, ... }: import ./modules/raspberry-pi-4.nix {
-          inherit config lib pkgs self;
-        };
+        base = import ./modules/raspberry-pi-4.nix;
         display-vc4 = import ./modules/display-vc4.nix;
         bluetooth = import ./modules/bluetooth.nix;
         # work-in-progress, untested
@@ -112,15 +101,11 @@
       };
 
       raspberry-pi-3 = {
-        base = { config, lib, pkgs, ... }: import ./modules/raspberry-pi-3.nix {
-          inherit config lib pkgs self;
-        };
+        base = import ./modules/raspberry-pi-3.nix;
       };
 
       raspberry-pi-02 = {
-        base = { config, lib, pkgs, ... }: import ./modules/raspberry-pi-02.nix {
-          inherit config lib pkgs self;
-        };
+        base = import ./modules/raspberry-pi-02.nix;
         display-vc4 = import ./modules/display-vc4.nix;
         bluetooth = import ./modules/bluetooth.nix;
       };

--- a/lib/internal.nix
+++ b/lib/internal.nix
@@ -7,10 +7,9 @@
     , rpiModules
     }:
     { modules, ... }@args:
-    assert nixpkgs.lib.assertMsg (args.specialArgs ? nixos-raspberrypi)
-      "specialArgs must provide nixos-raspberrypi";
     nixpkgs.lib.nixosSystem (
       builtins.removeAttrs args [ "nixpkgs" "trustCaches" ] // {
+        specialArgs = (args.specialArgs or {}) // { nixos-raspberrypi = self; };
         modules = rpiModules
           # Nix cache with prebuilt packages,
           # see `devshells/nix-build-to-cachix.nix` for a list

--- a/modules/nixpkgs-rpi.nix
+++ b/modules/nixpkgs-rpi.nix
@@ -1,25 +1,25 @@
-{ self, ... }:
+{ nixos-raspberrypi, ... }:
 
 {
   nixpkgs.overlays = [
     (final: prev: {
-      rpi = import self.inputs.nixpkgs {
+      rpi = import nixos-raspberrypi.inputs.nixpkgs {
         inherit (prev.stdenv.hostPlatform) system;
         config = {
           inherit (prev.config) allowUnfree allowUnfreePredicate;
         };
 
         overlays = [
-          self.overlays.bootloader
+          nixos-raspberrypi.overlays.bootloader
 
-          self.overlays.pkgs
+          nixos-raspberrypi.overlays.pkgs
 
-          self.overlays.vendor-pkgs
+          nixos-raspberrypi.overlays.vendor-pkgs
 
-          self.overlays.vendor-firmware
-          self.overlays.vendor-kernel
+          nixos-raspberrypi.overlays.vendor-firmware
+          nixos-raspberrypi.overlays.vendor-kernel
 
-          self.overlays.kernel-and-firmware
+          nixos-raspberrypi.overlays.kernel-and-firmware
         ];
       };
     })

--- a/modules/raspberry-pi-02.nix
+++ b/modules/raspberry-pi-02.nix
@@ -1,4 +1,4 @@
-{ self, lib, pkgs, ... }:
+{ nixos-raspberrypi, lib, pkgs, ... }:
 
 {
   imports = [ ./raspberrypi.nix ];
@@ -6,8 +6,8 @@
   boot.loader.raspberry-pi = {
     variant = "02";
     bootloader = lib.mkDefault "uboot";
-    firmwarePackage = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+    firmwarePackage = lib.mkDefault nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
   };
 
-  boot.kernelPackages = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi02;
+  boot.kernelPackages = lib.mkDefault nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi02;
 }

--- a/modules/raspberry-pi-3.nix
+++ b/modules/raspberry-pi-3.nix
@@ -1,4 +1,4 @@
-{ self, lib, pkgs, ... }:
+{ nixos-raspberrypi, lib, pkgs, ... }:
 
 {
   imports = [ ./raspberrypi.nix ];
@@ -6,8 +6,8 @@
   boot.loader.raspberry-pi = {
     variant = "3";
     bootloader = lib.mkDefault "uboot";
-    firmwarePackage = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+    firmwarePackage = lib.mkDefault nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
   };
 
-  boot.kernelPackages = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi3;
+  boot.kernelPackages = lib.mkDefault nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi3;
 }

--- a/modules/raspberry-pi-4.nix
+++ b/modules/raspberry-pi-4.nix
@@ -1,4 +1,4 @@
-{ self, lib, pkgs, ... }:
+{ nixos-raspberrypi, lib, pkgs, ... }:
 
 {
   imports = [ ./raspberrypi.nix ];
@@ -6,10 +6,10 @@
   boot.loader.raspberry-pi = {
     variant = "4";
     bootloader = lib.mkDefault "uboot";
-    firmwarePackage = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+    firmwarePackage = lib.mkDefault nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
   };
 
-  boot.kernelPackages = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi4;
+  boot.kernelPackages = lib.mkDefault nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi4;
   boot.initrd.availableKernelModules = [
     "nvme" # cm4 may have nvme drive connected with pcie
   ];

--- a/modules/raspberry-pi-5/default.nix
+++ b/modules/raspberry-pi-5/default.nix
@@ -1,4 +1,4 @@
-{ self, lib, pkgs, ... }:
+{ nixos-raspberrypi, lib, pkgs, ... }:
 
 {
   imports = [ ../raspberrypi.nix ];
@@ -6,10 +6,10 @@
   boot.loader.raspberry-pi = {
     variant = "5";
     bootloader = lib.mkDefault "kernelboot";
-    firmwarePackage = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+    firmwarePackage = lib.mkDefault nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
   };
 
-  boot.kernelPackages = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi5;
+  boot.kernelPackages = lib.mkDefault nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi5;
   boot.initrd.availableKernelModules = [
     "nvme" # nvme drive connected with pcie
   ];

--- a/modules/raspberry-pi-5/page-size-16k.nix
+++ b/modules/raspberry-pi-5/page-size-16k.nix
@@ -1,10 +1,10 @@
-{ self, lib, ... }:
+{ nixos-raspberrypi, lib, ... }:
 {
   # Optimizations or fixes for systems running
   # rpi5 (bcm2712-configured) Linux kernel 
   # See also: https://github.com/nvmd/nixos-raspberrypi/issues/64
   
   nixpkgs.overlays = lib.mkBefore [
-    self.overlays.jemalloc-page-size-16k
+    nixos-raspberrypi.overlays.jemalloc-page-size-16k
   ];
 }


### PR DESCRIPTION
Modules that need the flake self-reference (`self`) had two different patterns for receiving it:

1. Standard NixOS module signature with no wrapping
    - Used by modules that didn't need `self` e.g. `bluetooth.nix`, `display-vc4.nix`
3. A wrapping lambda in flake.nix that manually threaded `self` through
    - Used by every board module and `nixpkgs-rpi`

This meant `flake.nix` had a mix of `import ./module.nix` and `{ config, lib, pkgs, ... }: import ./module.nix { inherit config lib pkgs self; }` depending on whether the module needed the flake reference. Adding a new module that referenced the flake meant remembering to add the wrapper.

Now all modules use the same pattern: accept `nixos-raspberrypi` as a regular module argument, provided via `specialArgs`. `nixosSystemRPi` injects it automatically, so users of `lib.nixosSystem` / `lib.nixosSystemFull` / `lib.nixosInstaller` need no changes.

Users who call `nixpkgs.lib.nixosSystem` directly and import board modules must pass `nixos-raspberrypi` in `specialArgs`. This was already effectively required (`nixosSystemRPi` previously asserted its presence) but the assertion is now replaced by auto-injection.