### PR TITLE
README: document specialArgs requirement for direct nixpkgs.lib.nixosSystem usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ Options for a more fine-grained control:
 - Use regular `nixpkgs.lib.nixosSystem` importing the modules manually, see
 below
 
+> [!IMPORTANT]
+> When using `nixpkgs.lib.nixosSystem` directly you **must** pass
+> `nixos-raspberrypi` in `specialArgs` so that board modules can find the
+> flake reference:
+> ```nix
+> nixpkgs.lib.nixosSystem {
+>   specialArgs = { inherit (inputs) nixos-raspberrypi; };
+>   modules = [ ... ];
+> };
+> ```
+> The `nixos-raspberrypi.lib.nixosSystem` helpers do this automatically.
+
 ```nix
 imports = with nixos-raspberrypi.nixosModules; [
 


### PR DESCRIPTION
Since cdda49f, board modules get `nixos-raspberrypi` from `specialArgs` instead of wrapper lambdas. The `lib.nixosSystem` helpers inject it automatically, but users calling `nixpkgs.lib.nixosSystem` directly hit `error: attribute 'nixos-raspberrypi' missing` because nothing tells them to pass it.

This adds an IMPORTANT callout with a code snippet to the "advanced usage" README section showing how to wire up `specialArgs`.

Fixes #155