### PR TITLE
Use `final: prev:` in all overlays

### DIFF
--- a/overlays/bootloader.nix
+++ b/overlays/bootloader.nix
@@ -1,33 +1,33 @@
-self: super: {
+final: prev: {
   # see also
   # https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/misc/uboot/default.nix#L494
   # https://source.denx.de/u-boot/u-boot
   # https://github.com/u-boot/u-boot/
-  ubootRaspberryPi_64bit = super.buildUBoot rec {
+  ubootRaspberryPi_64bit = prev.buildUBoot rec {
     defconfig = "rpi_arm64_defconfig";
     extraMeta.platforms = [ "aarch64-linux" ];
     filesToInstall = [ "u-boot.bin" ];
     # version = "2024.04";
-    # src = super.fetchFromGitHub {
+    # src = prev.fetchFromGitHub {
     #   owner = "u-boot";
     #   repo = "u-boot";
     #   rev = "v${version}";
-    #   hash = super.fakeHash;
+    #   hash = prev.fakeHash;
     # };
   };
 
-  uefi_rpi3 = super.fetchzip {
+  uefi_rpi3 = prev.fetchzip {
     url = "https://github.com/pftf/RPi3/releases/download/v1.50/RPi3_UEFI_Firmware_v1.50.zip";
     hash = "sha256-R+hQn/Rgpg4ItSMOr0DiwOqgaQWz6m+WmPmdiid1yPE=";
     stripRoot = false;
   };
-  uefi_rpi4 = super.fetchzip {
+  uefi_rpi4 = prev.fetchzip {
     url = "https://github.com/pftf/RPi4/releases/download/v1.50/RPi4_UEFI_Firmware_v1.50.zip";
     hash = "sha256-g8046/Ox0hZgvU6u3ZfC6HMqoTME0Y7NsZD6NvUsp7w=";
     stripRoot = false;
   };
   # https://github.com/worproject/rpi5-uefi/
-  uefi_rpi5 = super.fetchzip {
+  uefi_rpi5 = prev.fetchzip {
     url = "https://github.com/worproject/rpi5-uefi/releases/download/v0.3/RPi5_UEFI_Release_v0.3.zip";
     hash = "sha256-bjEvq7KlEFANnFVL0LyexXEeoXj7rHGnwQpq09PhIb0=";
     stripRoot = false;

--- a/overlays/libpisp-default-config-path.nix
+++ b/overlays/libpisp-default-config-path.nix
@@ -1,15 +1,15 @@
-self: super: {
+final: prev: {
   # Fixes the issue https://github.com/nvmd/nixos-raspberrypi/issues/48
 
   # This overlay is to be removed once https://github.com/NixOS/nixpkgs/pull/429288
   # is upstreamed
-  libpisp = super.libpisp.overrideAttrs (old: {
+  libpisp = prev.libpisp.overrideAttrs (old: {
     preFixup = ''
       so=$out/lib/libpisp.so.1
       patchelf --set-soname $so $so
       patchelf --remove-rpath $so
       needed=$(patchelf --print-needed $so)
-      for pkg in ${super.glibc} ${super.boost} ${super.libgcc} ${super.stdenv.cc.cc.lib}; do
+      for pkg in ${prev.glibc} ${prev.boost} ${prev.libgcc} ${prev.stdenv.cc.cc.lib}; do
         for lib in $needed; do
           for libpath in $(find -L $pkg/lib -type f -name "$lib"); do
             patchelf --replace-needed $lib $libpath $so

--- a/overlays/linux-and-firmware.nix
+++ b/overlays/linux-and-firmware.nix
@@ -1,81 +1,81 @@
 let
   # linux kernel with compatible firmware
-  mkBundle = self: name: firmware: {
+  mkBundle = final: name: firmware: {
     "${name}" = rec {
-      linux_rpi5 = self."linux_rpi5_${name}";
-      linux_rpi4 = self."linux_rpi4_${name}";
-      linux_rpi3 = self."linux_rpi3_${name}";
-      linux_rpi02 = self."linux_rpi02_${name}";
+      linux_rpi5 = final."linux_rpi5_${name}";
+      linux_rpi4 = final."linux_rpi4_${name}";
+      linux_rpi3 = final."linux_rpi3_${name}";
+      linux_rpi02 = final."linux_rpi02_${name}";
 
-      linuxPackages_rpi5 = self.linuxPackagesFor linux_rpi5;
-      linuxPackages_rpi4 = self.linuxPackagesFor linux_rpi4;
-      linuxPackages_rpi3 = self.linuxPackagesFor linux_rpi3;
-      linuxPackages_rpi02 = self.linuxPackagesFor linux_rpi02;
+      linuxPackages_rpi5 = final.linuxPackagesFor linux_rpi5;
+      linuxPackages_rpi4 = final.linuxPackagesFor linux_rpi4;
+      linuxPackages_rpi3 = final.linuxPackagesFor linux_rpi3;
+      linuxPackages_rpi02 = final.linuxPackagesFor linux_rpi02;
     } // (with firmware; {
       raspberrypifw = fw;
       raspberrypiWirelessFirmware = wFw;
     });
   };
-in self: super: {
+in final: prev: {
 
-  inherit (self.linuxAndFirmware.default)
+  inherit (final.linuxAndFirmware.default)
     linux_rpi5 linuxPackages_rpi5
     linux_rpi4 linuxPackages_rpi4
     linux_rpi3 linuxPackages_rpi3
     linux_rpi02 linuxPackages_rpi02
     raspberrypifw raspberrypiWirelessFirmware;
 
-  linuxAndFirmware = super.lib.mergeAttrsList [
+  linuxAndFirmware = prev.lib.mergeAttrsList [
 
-    { default = self.linuxAndFirmware.v6_12_34; }
+    { default = final.linuxAndFirmware.v6_12_34; }
 
-    { latest = self.linuxAndFirmware.v6_12_47; }
+    { latest = final.linuxAndFirmware.v6_12_47; }
 
-    (mkBundle self "v6_12_47" {
-      fw = self.raspberrypifw_20250915;
-      wFw = self.raspberrypiWirelessFirmware_20251008;
+    (mkBundle final "v6_12_47" {
+      fw = final.raspberrypifw_20250915;
+      wFw = final.raspberrypiWirelessFirmware_20251008;
     })
 
-    (mkBundle self "v6_12_44" {
-      fw = self.raspberrypifw_20250829;
-      wFw = self.raspberrypiWirelessFirmware_20250408;
+    (mkBundle final "v6_12_44" {
+      fw = final.raspberrypifw_20250829;
+      wFw = final.raspberrypiWirelessFirmware_20250408;
     })
 
-    (mkBundle self "v6_12_34" {
-      fw = self.raspberrypifw_20250702;
-      wFw = self.raspberrypiWirelessFirmware_20250408;
+    (mkBundle final "v6_12_34" {
+      fw = final.raspberrypifw_20250702;
+      wFw = final.raspberrypiWirelessFirmware_20250408;
     })
 
-    (mkBundle self "v6_12_25" {
-      fw = self.raspberrypifw_20250430;
-      wFw = self.raspberrypiWirelessFirmware_20250408;
+    (mkBundle final "v6_12_25" {
+      fw = final.raspberrypifw_20250430;
+      wFw = final.raspberrypiWirelessFirmware_20250408;
     })
 
-    (mkBundle self "v6_6_74" {
-      fw = self.raspberrypifw_20250127;
-      wFw = self.raspberrypiWirelessFirmware_20241223;
+    (mkBundle final "v6_6_74" {
+      fw = final.raspberrypifw_20250127;
+      wFw = final.raspberrypiWirelessFirmware_20241223;
     })
 
-    (mkBundle self "v6_6_51" {
-      fw = self.raspberrypifw_20241008;
-      wFw = self.raspberrypiWirelessFirmware_20240226;
+    (mkBundle final "v6_6_51" {
+      fw = final.raspberrypifw_20241008;
+      wFw = final.raspberrypiWirelessFirmware_20240226;
     })
-    (mkBundle self "v6_6_31" {
-      fw = self.raspberrypifw_20240529;
-      wFw = self.raspberrypiWirelessFirmware_20240226;
+    (mkBundle final "v6_6_31" {
+      fw = final.raspberrypifw_20240529;
+      wFw = final.raspberrypiWirelessFirmware_20240226;
     })
-    (mkBundle self "v6_6_28" {
-      fw = self.raspberrypifw_20240424;
-      wFw = self.raspberrypiWirelessFirmware_20240226;
+    (mkBundle final "v6_6_28" {
+      fw = final.raspberrypifw_20240424;
+      wFw = final.raspberrypiWirelessFirmware_20240226;
     })
-    (mkBundle self "v6_1_73" {
-      fw = self.raspberrypifw_20240124;
+    (mkBundle final "v6_1_73" {
+      fw = final.raspberrypifw_20240124;
       # as seen in https://github.com/NixOS/nixpkgs/pull/292880:
-      wFw = self.raspberrypiWirelessFirmware_20240226;
+      wFw = final.raspberrypiWirelessFirmware_20240226;
     })
-    (mkBundle self "v6_1_63" {
-      fw = self.raspberrypifw_20231123;
-      wFw = self.raspberrypiWirelessFirmware_20231115;
+    (mkBundle final "v6_1_63" {
+      fw = final.raspberrypifw_20231123;
+      wFw = final.raspberrypiWirelessFirmware_20231115;
     })
   ];
 }

--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -1,52 +1,52 @@
-self: super: { # final: prev:
+final: prev: {
 
-  ffmpeg = self.ffmpeg_7;
-  ffmpeg-headless = self.ffmpeg_7-headless;
-  ffmpeg-full = self.ffmpeg_7-full;
+  ffmpeg = final.ffmpeg_7;
+  ffmpeg-headless = final.ffmpeg_7-headless;
+  ffmpeg-full = final.ffmpeg_7-full;
 
   ffmpeg_4 = (
-    super.callPackage ../pkgs/ffmpeg_4-rpi.nix {
-      ffmpeg = super.ffmpeg_4;
+    prev.callPackage ../pkgs/ffmpeg_4-rpi.nix {
+      ffmpeg = prev.ffmpeg_4;
     }
   ); # small
-  ffmpeg_4-headless = self.ffmpeg_4.override {
+  ffmpeg_4-headless = final.ffmpeg_4.override {
     ffmpegVariant = "headless";
   };
-  ffmpeg_4-full = self.ffmpeg_4.override {
+  ffmpeg_4-full = final.ffmpeg_4.override {
     ffmpegVariant = "full";
   };
 
   ffmpeg_6 = (
-    super.callPackage ../pkgs/ffmpeg_6-rpi.nix {
-      ffmpeg = super.ffmpeg_6;
+    prev.callPackage ../pkgs/ffmpeg_6-rpi.nix {
+      ffmpeg = prev.ffmpeg_6;
     }
   ); # small
-  ffmpeg_6-headless = self.ffmpeg_6.override {
+  ffmpeg_6-headless = final.ffmpeg_6.override {
     ffmpegVariant = "headless";
   };
-  ffmpeg_6-full = self.ffmpeg_6.override {
+  ffmpeg_6-full = final.ffmpeg_6.override {
     ffmpegVariant = "full";
   };
 
   ffmpeg_7 = (
-    super.callPackage ../pkgs/ffmpeg_7-rpi.nix {
-      ffmpeg = super.ffmpeg_7;
+    prev.callPackage ../pkgs/ffmpeg_7-rpi.nix {
+      ffmpeg = prev.ffmpeg_7;
     }
   ); # small
-  ffmpeg_7-headless = self.ffmpeg_7.override {
+  ffmpeg_7-headless = final.ffmpeg_7.override {
     ffmpegVariant = "headless";
   };
-  ffmpeg_7-full = self.ffmpeg_7.override {
+  ffmpeg_7-full = final.ffmpeg_7.override {
     ffmpegVariant = "full";
   };
 
 
-  kodi = (super.kodi.overrideAttrs (old: {
+  kodi = (prev.kodi.overrideAttrs (old: {
     pname = old.pname + "-rpi";
-    buildInputs = old.buildInputs ++ [ self.dav1d ];
+    buildInputs = old.buildInputs ++ [ final.dav1d ];
     cmakeFlags = let
       enableFeature = enable: feature:
-        assert (super.lib.isString feature);
+        assert (prev.lib.isString feature);
         "-DENABLE_${feature}=${if enable then "ON" else "OFF"}";
     in old.cmakeFlags ++ [
       "-DENABLE_INTERNAL_DAV1D=OFF"
@@ -66,24 +66,24 @@ self: super: { # final: prev:
     vdpauSupport = false;
   };
 
-  kodi-gbm = self.kodi.override {
+  kodi-gbm = final.kodi.override {
     gbmSupport = true;
   };
 
-  kodi-wayland = self.kodi.override {
+  kodi-wayland = final.kodi.override {
     waylandSupport = true;
     # nixos defaults to "gl" for wayland, but libreelec uses "gles"
     # renderSystem = "gles";
   };
 
 
-  libcamera = self.libcamera_rpi;
+  libcamera = final.libcamera_rpi;
 
-  libcamera_rpi = super.libcamera.overrideAttrs (old: rec {
+  libcamera_rpi = prev.libcamera.overrideAttrs (old: rec {
     pname = old.pname + "-rpi";
     version = "0.6.0+rpt20251202";
 
-    src = super.fetchFromGitHub {
+    src = prev.fetchFromGitHub {
       owner = "raspberrypi";
       repo = "libcamera";
       rev = "v${version}";
@@ -99,7 +99,7 @@ self: super: { # final: prev:
       "-Dtest=false"
       "-Dcam=disabled"
       "-Dpycamera=enabled"
-      (super.lib.mesonEnable "libunwind" false)
+      (prev.lib.mesonEnable "libunwind" false)
     ];
 
     meta = old.meta // {
@@ -108,12 +108,12 @@ self: super: { # final: prev:
     };
   });
 
-  vlc = super.vlc.overrideAttrs (old: {
+  vlc = prev.vlc.overrideAttrs (old: {
     pname = old.pname + "-rpi";
     version = "3.0.22-0+rpt1";
 
     # https://github.com/RPi-Distro/vlc/commits/pios/trixie
-    src = super.fetchFromGitHub {
+    src = prev.fetchFromGitHub {
       owner = "RPi-Distro";
       repo = "vlc";
       rev = "1e4f72f9f7af4de546c90062c248f6174af69f28";

--- a/overlays/vendor-firmware.nix
+++ b/overlays/vendor-firmware.nix
@@ -1,4 +1,4 @@
-self: super: { # final: prev:
+final: prev: {
 
   # https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
   # pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -6,10 +6,10 @@ self: super: { # final: prev:
 
   # see `extra/git_hash` for a matching hash of the `raspberrypi/linux`
 
-  raspberrypifw_20250915 = super.raspberrypifw.overrideAttrs (old: {
+  raspberrypifw_20250915 = prev.raspberrypifw.overrideAttrs (old: {
     # https://github.com/raspberrypi/firmware/releases/tag/1.20250915
     version = "1.20250915";
-    src = super.fetchFromGitHub {
+    src = prev.fetchFromGitHub {
       owner = "raspberrypi";
       repo = "firmware";
       rev = "676efed1194de38975889a34276091da1f5aadd3";
@@ -17,10 +17,10 @@ self: super: { # final: prev:
     };
   });
 
-  raspberrypifw_20250829 = super.raspberrypifw.overrideAttrs (old: {
+  raspberrypifw_20250829 = prev.raspberrypifw.overrideAttrs (old: {
     # this release is untagged in the upstream for linux 6.12.44
     version = "unstable_20250829";
-    src = super.fetchFromGitHub {
+    src = prev.fetchFromGitHub {
       owner = "raspberrypi";
       repo = "firmware";
       rev = "73065c21a0337eac9de13521fc1254cdadd3bd0a";
@@ -28,11 +28,11 @@ self: super: { # final: prev:
     };
   });
 
-  raspberrypifw_20250702 = super.raspberrypifw.overrideAttrs (old: {
+  raspberrypifw_20250702 = prev.raspberrypifw.overrideAttrs (old: {
     # this release is untagged in the upstream
     # this the the version of the matching stable kernel from `raspberrypi/linux`
     version = "1.20250702";
-    src = super.fetchFromGitHub {
+    src = prev.fetchFromGitHub {
       owner = "raspberrypi";
       repo = "firmware";
       rev = "7022a895240b2f853d9035ab61616b646caf7b3a";
@@ -40,10 +40,10 @@ self: super: { # final: prev:
     };
   });
 
-  raspberrypifw_20250430 = super.raspberrypifw.overrideAttrs (old: rec {
+  raspberrypifw_20250430 = prev.raspberrypifw.overrideAttrs (old: rec {
     # https://github.com/raspberrypi/firmware/releases/tag/1.20250430
     version = "1.20250430";
-    src = super.fetchFromGitHub {
+    src = prev.fetchFromGitHub {
       owner = "raspberrypi";
       repo = "firmware";
       rev = "${version}";
@@ -51,10 +51,10 @@ self: super: { # final: prev:
     };
   });
 
-  raspberrypifw_20250127 = super.raspberrypifw.overrideAttrs (old: rec {
+  raspberrypifw_20250127 = prev.raspberrypifw.overrideAttrs (old: rec {
     # https://github.com/raspberrypi/firmware/releases/tag/1.20250127
     version = "1.20250127";
-    src = super.fetchFromGitHub {
+    src = prev.fetchFromGitHub {
       owner = "raspberrypi";
       repo = "firmware";
       rev = "${version}";
@@ -62,10 +62,10 @@ self: super: { # final: prev:
     };
   });
 
-  raspberrypifw_20241008 = super.raspberrypifw.overrideAttrs (old: rec {
+  raspberrypifw_20241008 = prev.raspberrypifw.overrideAttrs (old: rec {
     # https://github.com/raspberrypi/firmware/releases/tag/1.20241008
     version = "1.20241008";
-    src = super.fetchFromGitHub {
+    src = prev.fetchFromGitHub {
       owner = "raspberrypi";
       repo = "firmware";
       rev = "${version}";
@@ -73,10 +73,10 @@ self: super: { # final: prev:
     };
   });
 
-  raspberrypifw_20240529 = super.raspberrypifw.overrideAttrs (old: rec {
+  raspberrypifw_20240529 = prev.raspberrypifw.overrideAttrs (old: rec {
     # https://github.com/raspberrypi/firmware/releases/tag/1.20240529
     version = "1.20240529";
-    src = super.fetchFromGitHub {
+    src = prev.fetchFromGitHub {
       owner = "raspberrypi";
       repo = "firmware";
       rev = "${version}";
@@ -84,12 +84,12 @@ self: super: { # final: prev:
     };
   });
 
-  raspberrypifw_20240424 = super.raspberrypifw.overrideAttrs (old: rec {
+  raspberrypifw_20240424 = prev.raspberrypifw.overrideAttrs (old: rec {
     # they seem to got back to releases
     # https://github.com/raspberrypi/firmware/releases/tag/1.20240424
     version = "1.20240424";
     # release tarball contains only the files we need
-    src = super.fetchFromGitHub {
+    src = prev.fetchFromGitHub {
       owner = "raspberrypi";
       repo = "firmware";
       rev = "${version}";
@@ -97,9 +97,9 @@ self: super: { # final: prev:
     };
   });
 
-  raspberrypifw_20240124 = super.raspberrypifw.overrideAttrs (old: {
+  raspberrypifw_20240124 = prev.raspberrypifw.overrideAttrs (old: {
     version = "stable_20240124";
-    src = super.fetchFromGitHub {
+    src = prev.fetchFromGitHub {
       owner = "raspberrypi";
       repo = "firmware";
       rev = "4649b6d52005b52b1d23f553b5e466941bc862dc";
@@ -108,9 +108,9 @@ self: super: { # final: prev:
   });
 
   # as in nixpkgs-unstable
-  raspberrypifw_20231123 = super.raspberrypifw.overrideAttrs (old: {
+  raspberrypifw_20231123 = prev.raspberrypifw.overrideAttrs (old: {
     version = "stable_20231123";
-    src = super.fetchFromGitHub {
+    src = prev.fetchFromGitHub {
       owner = "raspberrypi";
       repo = "firmware";
       rev = "524247ac6d8b1f4ddd53730e978a70c76a320bd6";
@@ -118,12 +118,12 @@ self: super: { # final: prev:
     };
   });
 
-  raspberrypiWirelessFirmware_20251008 = super.raspberrypiWirelessFirmware.overrideAttrs (old: {
+  raspberrypiWirelessFirmware_20251008 = prev.raspberrypiWirelessFirmware.overrideAttrs (old: {
     version = "2025-10-02";
     srcs = [
       # https://github.com/RPi-Distro/bluez-firmware/commits/pios/trixie
       # 1.2-13+rpt2 release – 20251002
-      (super.fetchFromGitHub {
+      (prev.fetchFromGitHub {
         name = "bluez-firmware";
         owner = "RPi-Distro";
         repo = "bluez-firmware";
@@ -132,7 +132,7 @@ self: super: { # final: prev:
       })
       # https://github.com/RPi-Distro/firmware-nonfree/commits/trixie
       # 20241210-1+rpt3 - 20250930
-      (super.fetchFromGitHub {
+      (prev.fetchFromGitHub {
         name = "firmware-nonfree";
         owner = "RPi-Distro";
         repo = "firmware-nonfree";
@@ -142,12 +142,12 @@ self: super: { # final: prev:
     ];
   });
 
-  raspberrypiWirelessFirmware_20250408 = super.raspberrypiWirelessFirmware.overrideAttrs (old: {
+  raspberrypiWirelessFirmware_20250408 = prev.raspberrypiWirelessFirmware.overrideAttrs (old: {
     version = "2025-04-08";
     srcs = [
       # https://github.com/RPi-Distro/bluez-firmware/commits/bookworm
       # 1.2-9+rpt3 release – 20240226
-      (super.fetchFromGitHub {
+      (prev.fetchFromGitHub {
         name = "bluez-firmware";
         owner = "RPi-Distro";
         repo = "bluez-firmware";
@@ -155,7 +155,7 @@ self: super: { # final: prev:
         hash = "sha256-KakKnOBeWxh0exu44beZ7cbr5ni4RA9vkWYb9sGMb8Q=";
       })
       # https://github.com/RPi-Distro/firmware-nonfree/commits/bookworm/
-      (super.fetchFromGitHub {
+      (prev.fetchFromGitHub {
         name = "firmware-nonfree";
         owner = "RPi-Distro";
         repo = "firmware-nonfree";
@@ -166,12 +166,12 @@ self: super: { # final: prev:
     __intentionallyOverridingVersion = true;
   });
 
-  raspberrypiWirelessFirmware_20241223 = super.raspberrypiWirelessFirmware.overrideAttrs (old: {
+  raspberrypiWirelessFirmware_20241223 = prev.raspberrypiWirelessFirmware.overrideAttrs (old: {
     version = "2024-12-23";
     srcs = [
       # https://github.com/RPi-Distro/bluez-firmware/commits/bookworm
       # 1.2-9+rpt3 release – 20240226
-      (super.fetchFromGitHub {
+      (prev.fetchFromGitHub {
         name = "bluez-firmware";
         owner = "RPi-Distro";
         repo = "bluez-firmware";
@@ -179,7 +179,7 @@ self: super: { # final: prev:
         hash = "sha256-KakKnOBeWxh0exu44beZ7cbr5ni4RA9vkWYb9sGMb8Q=";
       })
       # https://github.com/RPi-Distro/firmware-nonfree/commits/bookworm/
-      (super.fetchFromGitHub {
+      (prev.fetchFromGitHub {
         name = "firmware-nonfree";
         owner = "RPi-Distro";
         repo = "firmware-nonfree";
@@ -192,13 +192,13 @@ self: super: { # final: prev:
 
   # https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
   # pkgs/os-specific/linux/firmware/raspberrypi-wireless/default.nix
-  raspberrypiWirelessFirmware_20240226 = super.raspberrypiWirelessFirmware.overrideAttrs (old: {
+  raspberrypiWirelessFirmware_20240226 = prev.raspberrypiWirelessFirmware.overrideAttrs (old: {
     version = "2024-02-26";
     srcs = [
       # https://github.com/RPi-Distro/bluez-firmware/commits/bookworm
       # https://github.com/RPi-Distro/bluez-firmware/tree/78d6a07730e2d20c035899521ab67726dc028e1c
       # 1.2-9+rpt3 release – 20240226
-      (super.fetchFromGitHub {
+      (prev.fetchFromGitHub {
         name = "bluez-firmware";
         owner = "RPi-Distro";
         repo = "bluez-firmware";
@@ -208,7 +208,7 @@ self: super: { # final: prev:
       # https://github.com/RPi-Distro/firmware-nonfree/commits/bookworm/
       # https://github.com/RPi-Distro/firmware-nonfree/commit/4b356e134e8333d073bd3802d767a825adec3807
       # 20230625-2+rpt3 release – 20240826
-      (super.fetchFromGitHub {
+      (prev.fetchFromGitHub {
         name = "firmware-nonfree";
         owner = "RPi-Distro";
         repo = "firmware-nonfree";
@@ -219,13 +219,13 @@ self: super: { # final: prev:
     __intentionallyOverridingVersion = true;
   });
 
-  raspberrypiWirelessFirmware_20240117 = super.raspberrypiWirelessFirmware.overrideAttrs (old: {
+  raspberrypiWirelessFirmware_20240117 = prev.raspberrypiWirelessFirmware.overrideAttrs (old: {
     version = "2024-01-17";
     srcs = [
       # as in nixpkgs-unstable
       # https://github.com/RPi-Distro/bluez-firmware/commits/bookworm
       # 1.2-9+rpt2 release – 20231024
-      (super.fetchFromGitHub {
+      (prev.fetchFromGitHub {
         name = "bluez-firmware";
         owner = "RPi-Distro";
         repo = "bluez-firmware";
@@ -235,7 +235,7 @@ self: super: { # final: prev:
       # https://github.com/RPi-Distro/firmware-nonfree/commits/bookworm/
       # https://github.com/RPi-Distro/firmware-nonfree/tree/3db4164cfd89e6d9afb7ebc87607b792651512df
       # 1:20230210-5+rpt3 release – 20240117
-      (super.fetchFromGitHub {
+      (prev.fetchFromGitHub {
         name = "firmware-nonfree";
         owner = "RPi-Distro";
         repo = "firmware-nonfree";
@@ -247,17 +247,17 @@ self: super: { # final: prev:
   });
 
   # as in nixpkgs-unstable
-  raspberrypiWirelessFirmware_20231115 = super.raspberrypiWirelessFirmware.overrideAttrs (old: {
+  raspberrypiWirelessFirmware_20231115 = prev.raspberrypiWirelessFirmware.overrideAttrs (old: {
     version = "unstable-2023-11-15";
     srcs = [
-      (super.fetchFromGitHub {  # 1.2-9+rpt2 release – 20231024
+      (prev.fetchFromGitHub {  # 1.2-9+rpt2 release – 20231024
         name = "bluez-firmware";
         owner = "RPi-Distro";
         repo = "bluez-firmware";
         rev = "d9d4741caba7314d6500f588b1eaa5ab387a4ff5";
         hash = "sha256-CjbZ3t3TW/iJ3+t9QKEtM9NdQU7SwcUCDYuTmFEwvhU=";
       })
-      (super.fetchFromGitHub {  # 1:20230210-5+rpt2 release - 20231115
+      (prev.fetchFromGitHub {  # 1:20230210-5+rpt2 release - 20231115
         name = "firmware-nonfree";
         owner = "RPi-Distro";
         repo = "firmware-nonfree";

--- a/overlays/vendor-kernel.nix
+++ b/overlays/vendor-kernel.nix
@@ -35,11 +35,11 @@ let
 
       # https://github.com/NixOS/nixpkgs/blob/master/pkgs/os-specific/linux/kernel/linux-rpi.nix
       # overriding other override like this doesn't work
-      # linux_rpi5 = self.linux_rpi4.override {
+      # linux_rpi5 = final.linux_rpi4.override {
       #   rpiVersion = 5;
       #   argsOverride.defconfig = "bcm2712_defconfig";
       # };
-      # linux_rpi5_v6_6_28 = self.linux_rpi4_v6_6_28.override {
+      # linux_rpi5_v6_6_28 = final.linux_rpi4_v6_6_28.override {
       #   rpiVersion = 5;
       #   argsOverride = (linux_v6_6_28_argsOverride pkgs) // {
       #     defconfig = "bcm2712_defconfig";
@@ -48,16 +48,16 @@ let
     };
   in map linuxVersionForModel models;
 
-in self: super: super.lib.mergeAttrsList (
+in final: prev: prev.lib.mergeAttrsList (
   builtins.concatLists [
-    (mkLinuxFor super "6_12_47" [ "02" "3" "4" "5" ])
-    (mkLinuxFor super "6_12_44" [ "02" "3" "4" "5" ])
-    (mkLinuxFor super "6_12_34" [ "02" "3" "4" "5" ])
-    (mkLinuxFor super "6_12_25" [ "02" "3" "4" "5" ])
-    (mkLinuxFor super "6_6_74" [ "02" "4" "5" ])
-    (mkLinuxFor super "6_6_51" [ "02" "4" "5" ])
-    (mkLinuxFor super "6_6_31" [ "4" "5" ])
-    (mkLinuxFor super "6_6_28" [ "4" "5" ])
-    (mkLinuxFor super "6_1_73" [ "4" "5" ])
-    (mkLinuxFor super "6_1_63" [ "4" "5" ])
+    (mkLinuxFor prev "6_12_47" [ "02" "3" "4" "5" ])
+    (mkLinuxFor prev "6_12_44" [ "02" "3" "4" "5" ])
+    (mkLinuxFor prev "6_12_34" [ "02" "3" "4" "5" ])
+    (mkLinuxFor prev "6_12_25" [ "02" "3" "4" "5" ])
+    (mkLinuxFor prev "6_6_74" [ "02" "4" "5" ])
+    (mkLinuxFor prev "6_6_51" [ "02" "4" "5" ])
+    (mkLinuxFor prev "6_6_31" [ "4" "5" ])
+    (mkLinuxFor prev "6_6_28" [ "4" "5" ])
+    (mkLinuxFor prev "6_1_73" [ "4" "5" ])
+    (mkLinuxFor prev "6_1_63" [ "4" "5" ])
   ])

--- a/overlays/vendor-pkgs.nix
+++ b/overlays/vendor-pkgs.nix
@@ -1,17 +1,17 @@
-self: super: { # final: prev:
+final: prev: {
 
-  libraspberrypi = super.callPackage ../pkgs/raspberrypi/libraspberrypi.nix {};
+  libraspberrypi = prev.callPackage ../pkgs/raspberrypi/libraspberrypi.nix {};
 
-  raspberrypi-userland = self.libraspberrypi;
+  raspberrypi-userland = final.libraspberrypi;
 
-  raspberrypi-udev-rules = super.callPackage ../pkgs/raspberrypi/udev-rules.nix {};
+  raspberrypi-udev-rules = prev.callPackage ../pkgs/raspberrypi/udev-rules.nix {};
 
-  raspberrypi-utils = super.callPackage ../pkgs/raspberrypi/raspberrypi-utils.nix {};
+  raspberrypi-utils = prev.callPackage ../pkgs/raspberrypi/raspberrypi-utils.nix {};
 
-  rpi-userland = self.libraspberrypi;
+  rpi-userland = final.libraspberrypi;
 
-  rpicam-apps = super.callPackage ../pkgs/raspberrypi/rpicam-apps.nix {
-    libcamera = self.libcamera_rpi;
+  rpicam-apps = prev.callPackage ../pkgs/raspberrypi/rpicam-apps.nix {
+    libcamera = final.libcamera_rpi;
   };
 
 }


### PR DESCRIPTION
All 7 overlay files used `self: super:` for the parameter names. nixpkgs switched to `final: prev:` a while ago and we even had `# final: prev:` comments sitting next to the old names.

Pure rename, no logic changes. `jemalloc-page-size-16k.nix` already used `final: prev:` so it was left alone. The stale `# final: prev:` comments are removed since they're now redundant.
