### PR TITLE
ffmpeg: add ffmpeg_8

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -140,6 +140,8 @@
       ffmpeg_6 = pkgs.ffmpeg_6;
       ffmpeg_7 = pkgs.ffmpeg_7;
       ffmpeg_7-headless = pkgs.ffmpeg_7-headless;
+      ffmpeg_8 = pkgs.ffmpeg_8;
+      ffmpeg_8-headless = pkgs.ffmpeg_8-headless;
 
       kodi = pkgs.kodi;
       kodi-gbm = pkgs.kodi-gbm;

--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -40,6 +40,18 @@ final: prev: {
     ffmpegVariant = "full";
   };
 
+  ffmpeg_8 = (
+    prev.callPackage ../pkgs/ffmpeg_8-rpi.nix {
+      ffmpeg = prev.ffmpeg_8;
+    }
+  ); # small
+  ffmpeg_8-headless = final.ffmpeg_8.override {
+    ffmpegVariant = "headless";
+  };
+  ffmpeg_8-full = final.ffmpeg_8.override {
+    ffmpegVariant = "full";
+  };
+
 
   kodi = (prev.kodi.overrideAttrs (old: {
     pname = old.pname + "-rpi";

--- a/pkgs/ffmpeg-rpi.nix
+++ b/pkgs/ffmpeg-rpi.nix
@@ -5,6 +5,7 @@
 # disabled because i can't solve libepoxy not being found by ffmpeg confgure script
 , withVoutEgl ? false
 , withVoutDrm ? true
+, withSand ? true
 , version ? null
 , source ? null
 , ffmpegVariant ? "small"
@@ -27,7 +28,7 @@ in (ffmpeg.overrideAttrs (old: {
   ] ++ [
     "--disable-mmal"
     "--enable-neon"
-  ] ++ [
+  ] ++ lib.optionals withSand [
     "--enable-sand"
   ] ++ lib.optionals withVoutEgl [
     "--enable-epoxy"

--- a/pkgs/ffmpeg_8-rpi.nix
+++ b/pkgs/ffmpeg_8-rpi.nix
@@ -1,0 +1,27 @@
+{ lib, fetchFromGitHub
+, callPackage
+, ffmpeg
+, ffmpegVariant ? "small"
+}:
+
+let
+  # https://github.com/jc-kynesim/rpi-ffmpeg/releases/tag/n8.0
+  ffmpegVersion = "8.0";
+  rpiFfmpegSrc = fetchFromGitHub {
+    owner = "jc-kynesim";
+    repo  = "rpi-ffmpeg";
+    rev   = "n${ffmpegVersion}";
+    hash  = "sha256-okNZ1/m/thFAY3jK/GSV0+WZFnjrMr8uBPsOdH6Wq9E=";
+  };
+
+in callPackage ./ffmpeg-rpi.nix {
+  inherit ffmpeg;
+  version = ffmpegVersion;
+  source = rpiFfmpegSrc;
+  inherit ffmpegVariant;
+
+  # disable features unsupported by `configure`
+  withSand = false;
+  withVoutDrm = false;
+  withV4l2Request = false;
+}


### PR DESCRIPTION
This PR adds `ffmpeg_8` with Raspberry Pi optimizations by jc-kynesim.

FFMPEG 8 isn't yet made default `ffmpeg` package as in nixpkgs. From the point of view of this flake, this could be a breaking change for some, so these two changes will be released in two consecutive releases (and PRs).