### PR TITLE
ffmpeg: ffmpeg_8 is the default ffmpeg

### DIFF
--- a/devshells/nix-build-to-cachix.nix
+++ b/devshells/nix-build-to-cachix.nix
@@ -49,8 +49,8 @@ writeShellApplication {
     )
 
     declare -a packages=(
-      "ffmpeg_7"
-      "ffmpeg_7-headless"
+      "ffmpeg_8"
+      "ffmpeg_8-headless"
 
       # "kodi"
       "kodi-gbm"

--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -1,8 +1,8 @@
 final: prev: {
 
-  ffmpeg = final.ffmpeg_7;
-  ffmpeg-headless = final.ffmpeg_7-headless;
-  ffmpeg-full = final.ffmpeg_7-full;
+  ffmpeg = final.ffmpeg_8;
+  ffmpeg-headless = final.ffmpeg_8-headless;
+  ffmpeg-full = final.ffmpeg_8-full;
 
   ffmpeg_4 = (
     prev.callPackage ../pkgs/ffmpeg_4-rpi.nix {


### PR DESCRIPTION
This PR sets ffmpeg_8 as the default ffmpeg following nixpkgs. ffmpeg_8 was added in #161.
Due to potential backward compatibility issues, it is to be merged after the release containing #161.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nvmd/nixos-raspberrypi/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
