### PR TITLE
kernel 6.12.75, firmware 1.20260408

### DIFF
--- a/overlays/firmware-sources.nix
+++ b/overlays/firmware-sources.nix
@@ -2,6 +2,12 @@
 # https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
 [
   {
+    # https://github.com/raspberrypi/firmware/releases/tag/1.20260408
+    version = "1.20260408";
+    tag = "1.20260408";
+    srcHash = "sha256-4+eqk+3WxSZRfaGyRIW3zGC6ABo50PKGke0en2IvgXk=";
+  }
+  {
     # https://github.com/raspberrypi/firmware/releases/tag/1.20250915
     version = "1.20250915";
     tag = "1.20250915";

--- a/overlays/linux-and-firmware.nix
+++ b/overlays/linux-and-firmware.nix
@@ -38,9 +38,14 @@ in final: prev: {
 
   linuxAndFirmware = prev.lib.mergeAttrsList [
 
-    { default = final.linuxAndFirmware.v6_12_47; }
+    { default = final.linuxAndFirmware.v6_12_75; }
 
-    { latest = final.linuxAndFirmware.v6_12_47; }
+    { latest = final.linuxAndFirmware.v6_12_75; }
+
+    (mkBundle final "v6_12_75" {
+      fw = final.raspberrypifw_20260408;
+      wFw = final.raspberrypiWirelessFirmware_20251008;
+    })
 
     (mkBundle final "v6_12_47" {
       fw = final.raspberrypifw_20250915;

--- a/overlays/vendor-kernel.nix
+++ b/overlays/vendor-kernel.nix
@@ -49,6 +49,7 @@ let
 
 in final: prev: prev.lib.mergeAttrsList (
   builtins.concatLists [
+    (mkLinuxFor prev "6_12_75" [ "02" "3" "4" "5" ])
     (mkLinuxFor prev "6_12_47" [ "02" "3" "4" "5" ])
     (mkLinuxFor prev "6_12_44" [ "02" "3" "4" "5" ])
     (mkLinuxFor prev "6_12_34" [ "02" "3" "4" "5" ])

--- a/pkgs/linux-rpi/kernels.nix
+++ b/pkgs/linux-rpi/kernels.nix
@@ -13,6 +13,7 @@ let
   linux = listToAttrsWLVer (import ./linux-sources.nix);
 
 in listToAttrsWLVer [
+  linux.v6_12_75
   linux.v6_12_47
   linux.v6_12_44
   linux.v6_12_34

--- a/pkgs/linux-rpi/linux-sources.nix
+++ b/pkgs/linux-rpi/linux-sources.nix
@@ -1,5 +1,11 @@
 [
   {
+    modDirVersion = "6.12.75";
+    tag = "unstable_20260413";
+    rev = "89050b1059997d38d55462b323b099a6436dc10d"; # 6.12.75
+    srcHash = "sha256-qrljd20n4tj/7C7gzNnxw7JIyEF2Ppf1PWm2a7vxh1w=";
+  }
+  {
     # https://github.com/raspberrypi/linux/releases/tag/stable_20250916
     modDirVersion = "6.12.47";
     tag = "stable_20250916";


### PR DESCRIPTION
Matches the [2026-04-13 Raspberry Pi OS release][1].

- Linux kernel 6.12.75 (`89050b1059997d38d55462b323b099a6436dc10d`) - no stable tag yet, pinned by rev
- Firmware 1.20260408 (`dce3a7f35498e1a6340748f599e7d74d9001c1fe`)
- New default/latest bundle

[1]: https://downloads.raspberrypi.com/raspios_arm64/release_notes.txt