### PR TITLE
ci: test doc generation for modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  format:
-    name: Check formatting
-    runs-on: ubuntu-latest
+  check:
+    name: Check flake
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout repository
@@ -27,3 +27,6 @@ jobs:
 
       - name: Run formatter
         run: nix fmt . -- --ci
+
+      - name: Run checks
+        run: nix flake check

--- a/checks/options-doc.nix
+++ b/checks/options-doc.nix
@@ -1,0 +1,23 @@
+{ inputs }:
+let
+  lib = inputs.nixpkgs.lib;
+  eval =
+    module:
+    (inputs.self.lib.nixosSystem {
+      modules = [
+        {
+          # This forces evaluation of all types/descriptions in all modules
+          documentation.nixos.includeAllModules = true;
+        }
+        module
+      ];
+    }).config.system.build.manual.optionsJSON;
+  modules = lib.mapAttrsToListRecursive (attrPath: module: {
+    name = "options-${lib.concatStringsSep "-" attrPath}";
+    value = eval module;
+  }) inputs.self.nixosModules;
+in
+# Return the options JSON derivation.
+# If any option type has a circular reference or missing attribute,
+# evaluation will fail here.
+lib.listToAttrs modules

--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,29 @@
       # * binary cache is generated from this package set
       legacyPackages = mkLegacyPackagesFor nixpkgs;
 
+      kernelPackages = forSystems rpiSystems (
+        system:
+        let
+          pkgs = self.legacyPackages.${system};
+        in
+        {
+          # see legacyPackages.<system>.linuxAndFirmware for other versions of
+          # the bundle
+          inherit (pkgs.linuxAndFirmware.default)
+            linux_rpi5
+            linuxPackages_rpi5
+            linux_rpi4
+            linuxPackages_rpi4
+            linux_rpi3
+            linuxPackages_rpi3
+            linux_rpi02
+            linuxPackages_rpi02
+            raspberrypifw
+            raspberrypiWirelessFirmware
+            ;
+        }
+      );
+
       packages = forSystems rpiSystems (
         system:
         let
@@ -184,21 +207,6 @@
           rpicam-apps = pkgs.rpicam-apps;
 
           vlc = pkgs.vlc;
-
-          # see legacyPackages.<system>.linuxAndFirmware for other versions of
-          # the bundle
-          inherit (pkgs.linuxAndFirmware.default)
-            linux_rpi5
-            linuxPackages_rpi5
-            linux_rpi4
-            linuxPackages_rpi4
-            linux_rpi3
-            linuxPackages_rpi3
-            linux_rpi02
-            linuxPackages_rpi02
-            raspberrypifw
-            raspberrypiWirelessFirmware
-            ;
 
           argononed = pkgs.callPackage "${inputs.argononed}/OS/nixos/pkg.nix" { };
 

--- a/flake.nix
+++ b/flake.nix
@@ -397,5 +397,10 @@
           rpi5 = mkImage nixos.rpi5-installer;
         };
 
+      checks = {
+        # Because we use nixos-raspberrypi.lib.nixosSystem,
+        # only aarch64-linux is supported.
+        aarch64-linux = import ./checks/options-doc.nix { inherit inputs; };
+      };
     };
 }

--- a/modules/bluetooth.nix
+++ b/modules/bluetooth.nix
@@ -9,6 +9,8 @@ let
   cfg = config.hardware.raspberry-pi.bluetooth;
 in
 {
+  imports = [ ./configtxt-config.nix ];
+
   options.hardware.raspberry-pi.bluetooth = {
     enable = lib.mkEnableOption "Raspberry Pi Bluetooth support" // {
       default = true;

--- a/modules/configtxt-config.nix
+++ b/modules/configtxt-config.nix
@@ -90,6 +90,7 @@ in
                   str
                   bool
                 ];
+              description = "config.txt value.";
             };
           };
         };
@@ -105,6 +106,7 @@ in
                   bool
                 ]);
               default = null;
+              description = "Device tree parameter value.";
             };
           };
         };
@@ -114,6 +116,7 @@ in
             params = lib.mkOption {
               type = with lib.types; attrsOf (submodule dt-param);
               default = { };
+              description = "Device tree overlay parameters.";
             };
           };
         };

--- a/modules/installer/sd-card/sd-image-raspberrypi.nix
+++ b/modules/installer/sd-card/sd-image-raspberrypi.nix
@@ -10,6 +10,7 @@
   imports = [
     (modulesPath + "/profiles/base.nix")
     (modulesPath + "/installer/sd-card/sd-image.nix")
+    ../../system/boot/loader/raspberrypi
   ];
   # people say this module (imported by "sd-card/sd-image" above)
   # causes problems with linux-rpi

--- a/modules/pisugar-3.nix
+++ b/modules/pisugar-3.nix
@@ -8,6 +8,8 @@ let
   cfg = config.hardware.raspberry-pi.pisugar-3;
 in
 {
+  imports = [ ./configtxt-config.nix ];
+
   options.hardware.raspberry-pi.pisugar-3 = {
     enable = lib.mkEnableOption "PiSugar 3 battery module support" // {
       default = true;

--- a/modules/raspberry-pi-02.nix
+++ b/modules/raspberry-pi-02.nix
@@ -13,10 +13,10 @@
     bootloader = lib.mkDefault "uboot";
     firmwarePackage =
       lib.mkDefault
-        nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+        nixos-raspberrypi.kernelPackages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
   };
 
   boot.kernelPackages =
     lib.mkDefault
-      nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi02;
+      nixos-raspberrypi.kernelPackages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi02;
 }

--- a/modules/raspberry-pi-3.nix
+++ b/modules/raspberry-pi-3.nix
@@ -13,10 +13,10 @@
     bootloader = lib.mkDefault "uboot";
     firmwarePackage =
       lib.mkDefault
-        nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+        nixos-raspberrypi.kernelPackages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
   };
 
   boot.kernelPackages =
     lib.mkDefault
-      nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi3;
+      nixos-raspberrypi.kernelPackages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi3;
 }

--- a/modules/raspberry-pi-4.nix
+++ b/modules/raspberry-pi-4.nix
@@ -13,12 +13,12 @@
     bootloader = lib.mkDefault "uboot";
     firmwarePackage =
       lib.mkDefault
-        nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+        nixos-raspberrypi.kernelPackages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
   };
 
   boot.kernelPackages =
     lib.mkDefault
-      nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi4;
+      nixos-raspberrypi.kernelPackages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi4;
   boot.initrd.availableKernelModules = [
     "nvme" # cm4 may have nvme drive connected with pcie
   ];

--- a/modules/raspberry-pi-5/default.nix
+++ b/modules/raspberry-pi-5/default.nix
@@ -13,12 +13,12 @@
     bootloader = lib.mkDefault "kernelboot";
     firmwarePackage =
       lib.mkDefault
-        nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+        nixos-raspberrypi.kernelPackages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
   };
 
   boot.kernelPackages =
     lib.mkDefault
-      nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi5;
+      nixos-raspberrypi.kernelPackages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi5;
   boot.initrd.availableKernelModules = [
     "nvme" # nvme drive connected with pcie
   ];

--- a/modules/system/boot/loader/raspberrypi/default.nix
+++ b/modules/system/boot/loader/raspberrypi/default.nix
@@ -401,6 +401,7 @@ in
       };
 
       ubootPackage = lib.mkOption {
+        description = "The U-Boot package to use.";
         default =
           {
             "0" = {

--- a/modules/system/boot/loader/raspberrypi/default.nix
+++ b/modules/system/boot/loader/raspberrypi/default.nix
@@ -399,6 +399,7 @@ in
           "4"
           "5"
         ];
+        default = "5";
         description = "";
       };
 

--- a/modules/system/boot/loader/raspberrypi/default.nix
+++ b/modules/system/boot/loader/raspberrypi/default.nix
@@ -218,6 +218,8 @@ let
 in
 
 {
+  imports = [ ../../../../configtxt-config.nix ];
+
   options = {
 
     boot.loader.raspberry-pi = {

--- a/modules/trusted-nix-caches.nix
+++ b/modules/trusted-nix-caches.nix
@@ -1,3 +1,4 @@
+{ ... }:
 {
   nix.settings.substituters = [
     "https://nixos-raspberrypi.cachix.org"

--- a/modules/usb-gadget-ethernet.nix
+++ b/modules/usb-gadget-ethernet.nix
@@ -8,6 +8,8 @@ let
   cfg = config.hardware.raspberry-pi.usb-gadget-ethernet;
 in
 {
+  imports = [ ./configtxt-config.nix ];
+
   options.hardware.raspberry-pi.usb-gadget-ethernet = {
     enable = lib.mkEnableOption "USB Gadget/Ethernet (Ethernet emulation over USB)" // {
       default = true;


### PR DESCRIPTION
~~Having a formatter significantly improves code quality and also helps contributors maintain a consistent coding style. The code can be formatted by using the command `nix fmt`.~~

I have also added missing descriptions to options to fix `nixos-rebuild` when `documentation.nixos.includeAllModules` is enabled.