### PR TITLE
Use override for jemalloc-page-size-16k overlay

### DIFF
--- a/overlays/jemalloc-page-size-16k.nix
+++ b/overlays/jemalloc-page-size-16k.nix
@@ -1,14 +1,18 @@
 final: prev: {
   # https://github.com/nvmd/nixos-raspberrypi/issues/64
-  # credit for the initial version of this snippet goes to @micahcc
-  jemalloc = prev.jemalloc.overrideAttrs (old: {
-    # --with-lg-page=(log2 page_size)
-    # RPi5 (bcm2712): since our page size is 16384 (2**14), we need 14
-    configureFlags =
-      let
-        pageSizeFlag = "--with-lg-page";
-      in
-      (prev.lib.filter (flag: prev.lib.hasPrefix pageSizeFlag flag == false) old.configureFlags)
-      ++ [ "${pageSizeFlag}=14" ];
-  });
+  jemalloc =
+    if prev.lib.versionAtLeast prev.lib.trivial.release "26.05" then
+      prev.jemalloc.override { pageSizeKiB = 16; }
+    else
+      # credit for the initial version of this snippet goes to @micahcc
+      prev.jemalloc.overrideAttrs (old: {
+        # --with-lg-page=(log2 page_size)
+        # RPi5 (bcm2712): since our page size is 16384 (2**14), we need 14
+        configureFlags =
+          let
+            pageSizeFlag = "--with-lg-page";
+          in
+          (prev.lib.filter (flag: prev.lib.hasPrefix pageSizeFlag flag == false) old.configureFlags)
+          ++ [ "${pageSizeFlag}=14" ];
+      });
 }


### PR DESCRIPTION
The `pageSizeKiB` option was added in https://github.com/NixOS/nixpkgs/commit/e29eca25fc5c51f34a9af75c83a8f37a677522a7

Marking as draft as this should only be merged when nixpkgs gets bumped to 26.05