### PR TITLE
Kernel 6.12.87

### DIFF
--- a/overlays/linux-and-firmware.nix
+++ b/overlays/linux-and-firmware.nix
@@ -46,9 +46,14 @@ final: prev: {
 
   linuxAndFirmware = prev.lib.mergeAttrsList [
 
-    { default = final.linuxAndFirmware.v6_12_85; }
+    { default = final.linuxAndFirmware.v6_12_87; }
 
-    { latest = final.linuxAndFirmware.v6_12_85; }
+    { latest = final.linuxAndFirmware.v6_12_87; }
+
+    (mkBundle final "v6_12_87" {
+      fw = final.raspberrypifw_20260408;
+      wFw = final.raspberrypiWirelessFirmware_20251008;
+    })
 
     (mkBundle final "v6_12_85" {
       fw = final.raspberrypifw_20260408;

--- a/overlays/vendor-kernel.nix
+++ b/overlays/vendor-kernel.nix
@@ -67,6 +67,12 @@ in
 final: prev:
 prev.lib.mergeAttrsList (
   builtins.concatLists [
+    (mkLinuxFor prev "6_12_87" [
+      "02"
+      "3"
+      "4"
+      "5"
+    ])
     (mkLinuxFor prev "6_12_85" [
       "02"
       "3"

--- a/pkgs/linux-rpi/kernels.nix
+++ b/pkgs/linux-rpi/kernels.nix
@@ -23,6 +23,7 @@ let
 
 in
 listToAttrsWLVer [
+  linux.v6_12_87
   linux.v6_12_85
   linux.v6_12_75
   linux.v6_12_47

--- a/pkgs/linux-rpi/linux-sources.nix
+++ b/pkgs/linux-rpi/linux-sources.nix
@@ -1,5 +1,11 @@
 [
   {
+    modDirVersion = "6.12.87";
+    tag = "unstable_20260509";
+    rev = "ae4d75fb36deba0fe1a986d9bfae65755e082dd0"; # 6.12.87
+    srcHash = "sha256-vAjVe2f3+1+6HZCp7hfCEvS4XE2OveIRe/+3+oSFdZI=";
+  }
+  {
     modDirVersion = "6.12.85";
     tag = "unstable_20260430";
     rev = "effcbc88e3ab970a2d2aafdfe7c9333766f7139a"; # 6.12.85


### PR DESCRIPTION
This version has a fix for [Dirty Frag (CVE-2026-43284)](https://www.cve.org/CVERecord?id=CVE-2026-43284)

I tested that the kernel builds and boots successfully on a pi 5.