### PR TITLE
Add cross-compilation for installer images (small, targeted change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,49 @@ Latest stable version compatible with the board is selected in the flake module 
 
 overlays, containing vendor, and optimized packages, like `libcamera`, `ffmpeg`, etc.
 
+# Quick start
+
+Build a ready-to-flash SD card installer image for your board, without writing
+any configuration. Requires Nix with flakes enabled
+(`experimental-features = nix-command flakes`).
+
+1. Clone the repository:
+
+   ```shell
+   git clone https://github.com/nvmd/nixos-raspberrypi.git
+   cd nixos-raspberrypi
+   ```
+
+2. Build the image for your board (`rpi4` / `rpi5`, also `rpi02` / `rpi3`):
+
+   - On an **aarch64 (ARM) machine** (e.g. another Raspberry Pi), build natively:
+
+     ```shell
+     nix build .#installerImages.rpi5    # or .rpi4
+     ```
+
+   - On a **non-ARM machine** (e.g. `x86_64-linux`), cross-compile — no QEMU /
+     binfmt emulation needed:
+
+     ```shell
+     nix build .#installerImagesCross.rpi5    # or .rpi4
+     ```
+
+     > [!NOTE]
+     > Cross-compiled artifacts are not in the binary cache, so the first build
+     > compiles the kernel and many packages from source and can take a while.
+
+3. Flash the resulting image to an SD card (the `result` symlink points at it):
+
+   ```shell
+   zstdcat result/sd-image/*.img.zst | sudo dd of=/dev/sdX bs=10MB status=progress conv=fsync
+   ```
+
+   Replace `/dev/sdX` with your SD card device. Boot the Pi from it; randomly
+   generated login credentials are shown on screen on first boot.
+
+See [Installer configurations](#installer-configurations) below for more detail.
+
 # Usage
 
 ## Adding flake input
@@ -201,6 +244,23 @@ nix build .#installerImages.rpi3
 nix build .#installerImages.rpi4
 nix build .#installerImages.rpi5
 ```
+
+These build natively for `aarch64-linux`, so on an `x86_64-linux` host they
+require either binfmt/QEMU emulation (`boot.binfmt.emulatedSystems`) or remote
+aarch64 builders.
+
+To build on an `x86_64-linux` host **without** any emulation, use the
+cross-compiled variants instead (build host `x86_64-linux`, target `aarch64`):
+
+```
+nix build .#installerImagesCross.rpi02
+nix build .#installerImagesCross.rpi3
+nix build .#installerImagesCross.rpi4
+nix build .#installerImagesCross.rpi5
+```
+
+Note: cross-compiled artifacts are not in the binary cache, so the first build
+compiles the kernel and many packages from source.
 
 Randomly generated connection credentials will be displayed on the screen, once the system is booted.
 

--- a/flake.nix
+++ b/flake.nix
@@ -227,8 +227,14 @@
 
           # TIP: To create "regular" nixosConfigurations look for
           # `nixosSystem` and `nixosSystemFull` helpers in `lib/`
+          # `buildPlatform`, when non-null, cross-compiles the image from that
+          # build host (e.g. "x86_64-linux") to the aarch64 target, avoiding
+          # the need for binfmt/qemu emulation.
           mkNixOSRPiInstaller =
-            modules:
+            {
+              modules,
+              buildPlatform ? null,
+            }:
             self.lib.nixosInstaller {
               specialArgs = inputs // {
                 nixos-raspberrypi = self;
@@ -256,6 +262,9 @@
                   }
                 )
               ]
+              ++ nixpkgs.lib.optional (buildPlatform != null) {
+                nixpkgs.buildPlatform = buildPlatform;
+              }
               ++ modules;
             };
 
@@ -294,86 +303,68 @@
             }
           );
 
-        in
-        {
-
-          rpi02-installer = mkNixOSRPiInstaller [
-            (
-              {
-                config,
-                pkgs,
-                lib,
-                nixos-raspberrypi,
-                ...
-              }:
+          # Per-board hardware module imports, shared by the native and
+          # cross-compiled installer configurations below.
+          installerHwModules = {
+            rpi02 =
+              { nixos-raspberrypi, ... }:
               {
                 imports = with nixos-raspberrypi.nixosModules; [
                   # Hardware configuration
                   raspberry-pi-02.base
                   usb-gadget-ethernet
                 ];
-              }
-            )
-            custom-user-config
-          ];
-
-          rpi3-installer = mkNixOSRPiInstaller [
-            (
-              {
-                config,
-                pkgs,
-                lib,
-                nixos-raspberrypi,
-                ...
-              }:
+              };
+            rpi3 =
+              { nixos-raspberrypi, ... }:
               {
                 imports = with nixos-raspberrypi.nixosModules; [
                   # Hardware configuration
                   raspberry-pi-3.base
                 ];
-              }
-            )
-            custom-user-config
-          ];
-
-          rpi4-installer = mkNixOSRPiInstaller [
-            (
-              {
-                config,
-                pkgs,
-                lib,
-                nixos-raspberrypi,
-                ...
-              }:
+              };
+            rpi4 =
+              { nixos-raspberrypi, ... }:
               {
                 imports = with nixos-raspberrypi.nixosModules; [
                   # Hardware configuration
                   raspberry-pi-4.base
                 ];
-              }
-            )
-            custom-user-config
-          ];
-
-          rpi5-installer = mkNixOSRPiInstaller [
-            (
-              {
-                config,
-                pkgs,
-                lib,
-                nixos-raspberrypi,
-                ...
-              }:
+              };
+            rpi5 =
+              { nixos-raspberrypi, ... }:
               {
                 imports = with nixos-raspberrypi.nixosModules; [
                   # Hardware configuration
                   raspberry-pi-5.base
                   raspberry-pi-5.page-size-16k
                 ];
-              }
-            )
-            custom-user-config
-          ];
+              };
+          };
+
+          mkInstaller =
+            board: buildPlatform:
+            mkNixOSRPiInstaller {
+              inherit buildPlatform;
+              modules = [
+                installerHwModules.${board}
+                custom-user-config
+              ];
+            };
+
+        in
+        {
+
+          rpi02-installer = mkInstaller "rpi02" null;
+          rpi3-installer = mkInstaller "rpi3" null;
+          rpi4-installer = mkInstaller "rpi4" null;
+          rpi5-installer = mkInstaller "rpi5" null;
+
+          # Cross-compiled from x86_64-linux (no binfmt/qemu emulation needed)
+          rpi02-installer-cross = mkInstaller "rpi02" "x86_64-linux";
+          rpi3-installer-cross = mkInstaller "rpi3" "x86_64-linux";
+          rpi4-installer-cross = mkInstaller "rpi4" "x86_64-linux";
+          rpi5-installer-cross = mkInstaller "rpi5" "x86_64-linux";
 
         };
 
@@ -387,6 +378,20 @@
           rpi3 = mkImage nixos.rpi3-installer;
           rpi4 = mkImage nixos.rpi4-installer;
           rpi5 = mkImage nixos.rpi5-installer;
+        };
+
+      # Cross-compiled installer images (built on x86_64-linux for aarch64
+      # targets, no binfmt/qemu emulation needed).
+      installerImagesCross =
+        let
+          nixos = self.nixosConfigurations;
+          mkImage = nixosConfig: nixosConfig.config.system.build.sdImage;
+        in
+        {
+          rpi02 = mkImage nixos.rpi02-installer-cross;
+          rpi3 = mkImage nixos.rpi3-installer-cross;
+          rpi4 = mkImage nixos.rpi4-installer-cross;
+          rpi5 = mkImage nixos.rpi5-installer-cross;
         };
 
     };

--- a/modules/nixpkgs-rpi.nix
+++ b/modules/nixpkgs-rpi.nix
@@ -3,25 +3,36 @@
 {
   nixpkgs.overlays = [
     (final: prev: {
-      rpi = import nixos-raspberrypi.inputs.nixpkgs {
-        inherit (prev.stdenv.hostPlatform) system;
-        config = {
-          inherit (prev.config) allowUnfree allowUnfreePredicate;
-        };
+      rpi = import nixos-raspberrypi.inputs.nixpkgs (
+        {
+          # Preserve the build/host platform split so that `pkgs.rpi` is
+          # cross-compiled too when the enclosing nixpkgs is cross-compiled
+          # (build != host). Otherwise this re-import would build natively for
+          # the host platform, requiring emulation (binfmt).
+          localSystem = { inherit (prev.stdenv.buildPlatform) system; };
+          config = {
+            inherit (prev.config) allowUnfree allowUnfreePredicate;
+          };
 
-        overlays = [
-          nixos-raspberrypi.overlays.bootloader
+          overlays = [
+            nixos-raspberrypi.overlays.bootloader
 
-          nixos-raspberrypi.overlays.pkgs
+            nixos-raspberrypi.overlays.pkgs
 
-          nixos-raspberrypi.overlays.vendor-pkgs
+            nixos-raspberrypi.overlays.vendor-pkgs
 
-          nixos-raspberrypi.overlays.vendor-firmware
-          nixos-raspberrypi.overlays.vendor-kernel
+            nixos-raspberrypi.overlays.vendor-firmware
+            nixos-raspberrypi.overlays.vendor-kernel
 
-          nixos-raspberrypi.overlays.kernel-and-firmware
-        ];
-      };
+            nixos-raspberrypi.overlays.kernel-and-firmware
+          ];
+        }
+        // prev.lib.optionalAttrs
+          (prev.stdenv.buildPlatform.system != prev.stdenv.hostPlatform.system)
+          {
+            crossSystem = { inherit (prev.stdenv.hostPlatform) system; };
+          }
+      );
     })
   ];
 }


### PR DESCRIPTION
G'day @nvmd! 👋

This is a much smaller, more targeted follow-up to #163.

That PR was large and bundled the cross-compilation work together with a big kernel/firmware refactor. I understand that is a lot to review at once. So this PR does **only one thing**: it adds cross-compilation for the installer SD images. This is the main feature we want and need — building the aarch64 images on an x86_64 machine **without** binfmt/QEMU emulation.

It is built on top of the current `develop`, so no refactor is included.

## What this PR does

- **flake:** add `installerImagesCross.{rpi02,rpi3,rpi4,rpi5}` outputs and matching `rpiN-installer-cross` nixosConfigurations. They build on `x86_64-linux` and target `aarch64-linux`.
- **flake:** `mkNixOSRPiInstaller` now takes a `buildPlatform` argument. When it is set, the builder sets `nixpkgs.buildPlatform`, which turns on cross-compilation.
- **nixpkgs-rpi:** `pkgs.rpi` now keeps the build/host platform split. Before, it always used the host system, so it was built natively and needed emulation. Now it is cross-compiled too when build != host.
- The existing native `installerImages.*` outputs do **not** change.
- **README:** add a "Quick start" section, and document the cross build commands.

## How to build

Native (on an ARM machine), same as before:
```bash
nix build .#installerImages.rpi5    # or .rpi4
```

Cross (on x86_64, no emulation), new:
```bash
nix build .#installerImagesCross.rpi5    # or .rpi4
```

## Testing

Cross-built the rpi4 and rpi5 installer images on `x86_64-linux` with no emulation. The build compiles its own `aarch64-unknown-linux-gnu` toolchain, which confirms it is really cross-compiling.

Note: cross-compiled artifacts are not in the binary cache, so the first build compiles the kernel and many packages from source.

If you would prefer a different name for the outputs, or a different way to turn on cross-compilation, happy to change it. 🙂

Thanks again for the great repo, and for all the recent improvements — it is much appreciated!

🤖 Generated with [Claude Code](https://claude.com/claude-code)