### PR TITLE
feat: enable proper cross-compilation (x86_64 → aarch64) for all board modules

### DIFF
--- a/modules/nixpkgs-rpi.nix
+++ b/modules/nixpkgs-rpi.nix
@@ -19,11 +19,9 @@
             nixos-raspberrypi.overlays.kernel-and-firmware
           ];
         }
-        // prev.lib.optionalAttrs
-          (prev.stdenv.buildPlatform.system != prev.stdenv.hostPlatform.system)
-          {
-            crossSystem = { inherit (prev.stdenv.hostPlatform) system; };
-          }
+        // prev.lib.optionalAttrs (prev.stdenv.buildPlatform.system != prev.stdenv.hostPlatform.system) {
+          crossSystem = { inherit (prev.stdenv.hostPlatform) system; };
+        }
       );
     })
   ];

--- a/modules/nixpkgs-rpi.nix
+++ b/modules/nixpkgs-rpi.nix
@@ -3,25 +3,28 @@
 {
   nixpkgs.overlays = [
     (final: prev: {
-      rpi = import nixos-raspberrypi.inputs.nixpkgs {
-        inherit (prev.stdenv.hostPlatform) system;
-        config = {
-          inherit (prev.config) allowUnfree allowUnfreePredicate;
-        };
+      rpi = import nixos-raspberrypi.inputs.nixpkgs (
+        {
+          localSystem = { inherit (prev.stdenv.buildPlatform) system; };
+          config = {
+            inherit (prev.config) allowUnfree allowUnfreePredicate;
+          };
 
-        overlays = [
-          nixos-raspberrypi.overlays.bootloader
-
-          nixos-raspberrypi.overlays.pkgs
-
-          nixos-raspberrypi.overlays.vendor-pkgs
-
-          nixos-raspberrypi.overlays.vendor-firmware
-          nixos-raspberrypi.overlays.vendor-kernel
-
-          nixos-raspberrypi.overlays.kernel-and-firmware
-        ];
-      };
+          overlays = [
+            nixos-raspberrypi.overlays.bootloader
+            nixos-raspberrypi.overlays.pkgs
+            nixos-raspberrypi.overlays.vendor-pkgs
+            nixos-raspberrypi.overlays.vendor-firmware
+            nixos-raspberrypi.overlays.vendor-kernel
+            nixos-raspberrypi.overlays.kernel-and-firmware
+          ];
+        }
+        // prev.lib.optionalAttrs
+          (prev.stdenv.buildPlatform.system != prev.stdenv.hostPlatform.system)
+          {
+            crossSystem = { inherit (prev.stdenv.hostPlatform) system; };
+          }
+      );
     })
   ];
 }

--- a/modules/raspberry-pi-02.nix
+++ b/modules/raspberry-pi-02.nix
@@ -13,10 +13,10 @@
     bootloader = lib.mkDefault "uboot";
     firmwarePackage =
       lib.mkDefault
-        nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+        pkgs.rpi.raspberrypifw;
   };
 
   boot.kernelPackages =
     lib.mkDefault
-      nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi02;
+      pkgs.rpi.linuxPackages_rpi02;
 }

--- a/modules/raspberry-pi-02.nix
+++ b/modules/raspberry-pi-02.nix
@@ -11,12 +11,8 @@
   boot.loader.raspberry-pi = {
     variant = "02";
     bootloader = lib.mkDefault "uboot";
-    firmwarePackage =
-      lib.mkDefault
-        pkgs.rpi.raspberrypifw;
+    firmwarePackage = lib.mkDefault pkgs.rpi.raspberrypifw;
   };
 
-  boot.kernelPackages =
-    lib.mkDefault
-      pkgs.rpi.linuxPackages_rpi02;
+  boot.kernelPackages = lib.mkDefault pkgs.rpi.linuxPackages_rpi02;
 }

--- a/modules/raspberry-pi-3.nix
+++ b/modules/raspberry-pi-3.nix
@@ -13,10 +13,10 @@
     bootloader = lib.mkDefault "uboot";
     firmwarePackage =
       lib.mkDefault
-        nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+        pkgs.rpi.raspberrypifw;
   };
 
   boot.kernelPackages =
     lib.mkDefault
-      nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi3;
+      pkgs.rpi.linuxPackages_rpi3;
 }

--- a/modules/raspberry-pi-3.nix
+++ b/modules/raspberry-pi-3.nix
@@ -11,12 +11,8 @@
   boot.loader.raspberry-pi = {
     variant = "3";
     bootloader = lib.mkDefault "uboot";
-    firmwarePackage =
-      lib.mkDefault
-        pkgs.rpi.raspberrypifw;
+    firmwarePackage = lib.mkDefault pkgs.rpi.raspberrypifw;
   };
 
-  boot.kernelPackages =
-    lib.mkDefault
-      pkgs.rpi.linuxPackages_rpi3;
+  boot.kernelPackages = lib.mkDefault pkgs.rpi.linuxPackages_rpi3;
 }

--- a/modules/raspberry-pi-4.nix
+++ b/modules/raspberry-pi-4.nix
@@ -11,14 +11,10 @@
   boot.loader.raspberry-pi = {
     variant = "4";
     bootloader = lib.mkDefault "uboot";
-    firmwarePackage =
-      lib.mkDefault
-        pkgs.rpi.raspberrypifw;
+    firmwarePackage = lib.mkDefault pkgs.rpi.raspberrypifw;
   };
 
-  boot.kernelPackages =
-    lib.mkDefault
-      pkgs.rpi.linuxPackages_rpi4;
+  boot.kernelPackages = lib.mkDefault pkgs.rpi.linuxPackages_rpi4;
   boot.initrd.availableKernelModules = [
     "nvme" # cm4 may have nvme drive connected with pcie
   ];

--- a/modules/raspberry-pi-4.nix
+++ b/modules/raspberry-pi-4.nix
@@ -13,12 +13,12 @@
     bootloader = lib.mkDefault "uboot";
     firmwarePackage =
       lib.mkDefault
-        nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+        pkgs.rpi.raspberrypifw;
   };
 
   boot.kernelPackages =
     lib.mkDefault
-      nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi4;
+      pkgs.rpi.linuxPackages_rpi4;
   boot.initrd.availableKernelModules = [
     "nvme" # cm4 may have nvme drive connected with pcie
   ];

--- a/modules/raspberry-pi-5/default.nix
+++ b/modules/raspberry-pi-5/default.nix
@@ -13,12 +13,12 @@
     bootloader = lib.mkDefault "kernelboot";
     firmwarePackage =
       lib.mkDefault
-        nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+        pkgs.rpi.raspberrypifw;
   };
 
   boot.kernelPackages =
     lib.mkDefault
-      nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi5;
+      pkgs.rpi.linuxPackages_rpi5;
   boot.initrd.availableKernelModules = [
     "nvme" # nvme drive connected with pcie
   ];

--- a/modules/raspberry-pi-5/default.nix
+++ b/modules/raspberry-pi-5/default.nix
@@ -11,14 +11,10 @@
   boot.loader.raspberry-pi = {
     variant = "5";
     bootloader = lib.mkDefault "kernelboot";
-    firmwarePackage =
-      lib.mkDefault
-        pkgs.rpi.raspberrypifw;
+    firmwarePackage = lib.mkDefault pkgs.rpi.raspberrypifw;
   };
 
-  boot.kernelPackages =
-    lib.mkDefault
-      pkgs.rpi.linuxPackages_rpi5;
+  boot.kernelPackages = lib.mkDefault pkgs.rpi.linuxPackages_rpi5;
   boot.initrd.availableKernelModules = [
     "nvme" # nvme drive connected with pcie
   ];


### PR DESCRIPTION
## Problem

When cross-compiling (x86_64 to aarch64) with `nixpkgs.buildPlatform = "x86_64-linux"`, all board modules source kernel and firmware from:

```nix
nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi5
```

During cross-compilation, `hostPlatform` resolves to `"aarch64-linux"`, which looks up packages from `mkRpiPkgs`:

```nix
import nixpkgs { system = "aarch64-linux"; ... }
```

This is always a native aarch64 import, forcing QEMU user emulation for all kernel/firmware builds.

## Solution

**1. modules/nixpkgs-rpi.nix** — use `localSystem` + `crossSystem` instead of `system` alone, so the re-imported `pkgs.rpi` respects cross-compilation when `buildPlatform != hostPlatform`.

**2. All board modules** — use `pkgs.rpi.linuxPackages_rpiX` / `pkgs.rpi.raspberrypifw` instead of `nixos-raspberrypi.packages.${system}.linuxPackages_rpiX` / `.raspberrypifw`. The module-level `pkgs.rpi` is now properly cross-compiled by fix #1.

This also aligns the board modules with the project architecture: `pkgs.rpi` (via `nixpkgs-rpi`) is the module-level internal API, while `nixos-raspberrypi.packages` is the flake-level public API for external consumers.

## Files changed

- modules/nixpkgs-rpi.nix
- modules/raspberry-pi-5/default.nix
- modules/raspberry-pi-4.nix
- modules/raspberry-pi-3.nix
- modules/raspberry-pi-02.nix

## Impact

- Cross-compilation works without QEMU: kernel, firmware, bootloader compile with the `aarch64-unknown-linux-gnu` toolchain
- No change for native aarch64 builds — identical results
- Tested on real CM5 hardware (uConsole) with cross-compiled SD image
- Related: PR #192 and PR #163 (neither addresses the board module package source)