### PR TITLE
bootloader: bump backward-compatibility version check to 26.11

### DIFF
--- a/modules/system/boot/loader/raspberrypi/default.nix
+++ b/modules/system/boot/loader/raspberrypi/default.nix
@@ -533,7 +533,7 @@ in
           build.installBootLoader = builder.${cfg.bootloader};
           boot.loader.id = "raspberrypi-${cfg.bootloader}";
           boot.loader.kernelFile =
-            if lib.versionAtLeast lib.trivial.release "26.05" then
+            if lib.versionAtLeast lib.trivial.release "26.11" then
               config.boot.kernelPackages.kernel.target
             else
               pkgs.stdenv.hostPlatform.linux-kernel.target;


### PR DESCRIPTION
Hi! Thanks for maintaining this project! I believe the kernel configuration change was only made after NixOS 26.05 was released (https://github.com/NixOS/nixpkgs/pull/530133). Evaluation therefore fails when using the latest stable channel.