### PR TITLE
Fix NixOS 26.05 builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -253,6 +253,11 @@
                         cfg = config.boot.loader.raspberry-pi;
                       in
                       lib.mkOverride 40 "nixos-installer-rpi${cfg.variant}-${cfg.bootloader}";
+
+                    # nixos-images' installer Wi-Fi module uses iwd and disables
+                    # the legacy wpa_supplicant path. NixOS 26.05 enables it via
+                    # NetworkManager, so keep the installer module's intent.
+                    networking.wireless.enable = lib.mkForce false;
                   }
                 )
               ]


### PR DESCRIPTION
Fix repeatly failing NixOS 26.05 builds.

Remote checks: https://github.com/cniry/nixos-raspberrypi/pull/1

Pls @nvmd  