### PR TITLE
Cross comp support: use pkgs for kernel packages in the nixos modules

### DIFF
--- a/modules/raspberry-pi-02.nix
+++ b/modules/raspberry-pi-02.nix
@@ -13,10 +13,10 @@
     bootloader = lib.mkDefault "uboot";
     firmwarePackage =
       lib.mkDefault
-        nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+        pkgs.raspberrypifw;
   };
 
   boot.kernelPackages =
     lib.mkDefault
-      nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi02;
+      pkgs.linuxPackages_rpi02;
 }

--- a/modules/raspberry-pi-3.nix
+++ b/modules/raspberry-pi-3.nix
@@ -13,10 +13,10 @@
     bootloader = lib.mkDefault "uboot";
     firmwarePackage =
       lib.mkDefault
-        nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+        pkgs.raspberrypifw;
   };
 
   boot.kernelPackages =
     lib.mkDefault
-      nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi3;
+      pkgs.linuxPackages_rpi3;
 }

--- a/modules/raspberry-pi-4.nix
+++ b/modules/raspberry-pi-4.nix
@@ -13,12 +13,12 @@
     bootloader = lib.mkDefault "uboot";
     firmwarePackage =
       lib.mkDefault
-        nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+        pkgs.raspberrypifw;
   };
 
   boot.kernelPackages =
     lib.mkDefault
-      nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi4;
+      pkgs.linuxPackages_rpi4;
   boot.initrd.availableKernelModules = [
     "nvme" # cm4 may have nvme drive connected with pcie
   ];

--- a/modules/raspberry-pi-5/default.nix
+++ b/modules/raspberry-pi-5/default.nix
@@ -13,12 +13,12 @@
     bootloader = lib.mkDefault "kernelboot";
     firmwarePackage =
       lib.mkDefault
-        nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.raspberrypifw;
+        pkgs.raspberrypifw;
   };
 
   boot.kernelPackages =
     lib.mkDefault
-      nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi5;
+      pkgs.linuxPackages_rpi5;
   boot.initrd.availableKernelModules = [
     "nvme" # nvme drive connected with pcie
   ];


### PR DESCRIPTION
In the same vein as https://github.com/nvmd/nixos-raspberrypi/pull/214

This made cross comp work for me. Without it, when I have `buildPlatform = "x86_64-linux"` and `hostPlatform = "aarch64-linux"` in my config, the kernal packages are still set to `nixos-raspberrypi.packages.${pkgs.stdenv.hostPlatform.system}.linuxPackages_rpi5;` which means they'll have `hostPlatform` as their `buildPlatform`.

Overlays will add these packages, and by using them we'll get the configured platforms.

Noticed this because the `sdImage` wanted `zfs` for the supported boot filesystems but the `zfs` module package refused to build because it had `system = "aarch64-linux"`