### PR TITLE
fix(firmware-builder.sh): create target directory if missing

### DIFF
--- a/modules/system/boot/loader/raspberrypi/firmware-builder.sh
+++ b/modules/system/boot/loader/raspberrypi/firmware-builder.sh
@@ -21,6 +21,10 @@ while getopts "c:d:r" opt; do
     esac
 done
 
+if [ ! -d "$target" ]; then
+       mkdir -p "$target"
+fi
+
 # Copy a file from the Nix store to $target.
 declare -A filesCopied
 


### PR DESCRIPTION
When using this flake in conjunction with `disko-install` on a fresh disk, my boot partition was missing the firmware directory (/boot/firmware). The firmware builder assumes that the directory exists; if not, files are copied with `cp` which exits if a directory does not exist. This patch creates the `target` directory if it's missing.