### PR TITLE
configtxt: use lib.mkDefault for audio dtparam

### DIFF
--- a/modules/configtxt.nix
+++ b/modules/configtxt.nix
@@ -78,7 +78,7 @@
 
         # Enable audio (loads snd_bcm2835)
         audio = {
-          enable = true;
+          enable = lib.mkDefault true;
           value = "on";
         };
       };


### PR DESCRIPTION
If this option is disabled by the user in another module, that setting conflicts with the definition value here. Wrap in lib.mkDefault to allow user to change the value without overriding the module option priority.