### PR TITLE
Release 1.20260801.1

### DIFF
--- a/.github/workflows/build-installer-images.yaml
+++ b/.github/workflows/build-installer-images.yaml
@@ -16,7 +16,7 @@ jobs:
         version: ["02", "3", "4", "5"]
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-nix-action
 
       - name: Build image for RPi ${{ matrix.version }}

--- a/.github/workflows/cachix.yaml
+++ b/.github/workflows/cachix.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-nix-action
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-nix-action
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-nix-action
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-nix-action
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         
       - name: Install Nix
         uses: ./.github/actions/setup-nix-action

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -13,5 +13,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3.21.2
+      - uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
       - uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -12,6 +12,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: DeterminateSystems/determinate-nix-action@d96678350ffd6a456235832eb11e1c491589b7bb # v3.21.8
       - uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -40,7 +40,7 @@ jobs:
           #   args: "--version=branch=pios/trixie"
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-nix-action
 
       - name: Run nix-update for ${{ matrix.attr }}

--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783703440,
-        "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
+        "lastModified": 1784280462,
+        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8f0500b9660505dc3cb647775fe9a978a74b5283",
+        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784280462,
-        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
+        "lastModified": 1784856561,
+        "narHash": "sha256-J+Bx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
+        "rev": "597283ad8aa0b331c788e97c4c262d58877074ef",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783148766,
-        "narHash": "sha256-uslt2pqShTIXDdAHRHv2QkYLsVdY8Oqwz0EA48/RSM8=",
+        "lastModified": 1783549019,
+        "narHash": "sha256-0XnckG4ZhBmAsYa9mLuEIFowBG0fDGPLHduQGsbMS4A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a50de1b7d8a586adc18d2395c19de7d6058e6030",
+        "rev": "74cc63f702f7d60a557e152a57b40fb1fd0f72ac",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -57,16 +57,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782847189,
-        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "lastModified": 1783148766,
+        "narHash": "sha256-uslt2pqShTIXDdAHRHv2QkYLsVdY8Oqwz0EA48/RSM8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "rev": "a50de1b7d8a586adc18d2395c19de7d6058e6030",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783549019,
-        "narHash": "sha256-0XnckG4ZhBmAsYa9mLuEIFowBG0fDGPLHduQGsbMS4A=",
+        "lastModified": 1783703440,
+        "narHash": "sha256-O3/YajjWo001VUIgD8BwaRdSNLUFe7nZ1qV5TwhRBcw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "74cc63f702f7d60a557e152a57b40fb1fd0f72ac",
+        "rev": "8f0500b9660505dc3cb647775fe9a978a74b5283",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -253,6 +253,11 @@
                         cfg = config.boot.loader.raspberry-pi;
                       in
                       lib.mkOverride 40 "nixos-installer-rpi${cfg.variant}-${cfg.bootloader}";
+
+                    # nixos-images' installer Wi-Fi module uses iwd and disables
+                    # the legacy wpa_supplicant path. NixOS 26.05 enables it via
+                    # NetworkManager, so keep the installer module's intent.
+                    networking.wireless.enable = lib.mkForce false;
                   }
                 )
               ]

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
     argononed = {
       # url = "git+file:../argononed?shallow=1";

--- a/modules/configtxt.nix
+++ b/modules/configtxt.nix
@@ -78,7 +78,7 @@
 
         # Enable audio (loads snd_bcm2835)
         audio = {
-          enable = true;
+          enable = lib.mkDefault true;
           value = "on";
         };
       };

--- a/overlays/vendor-kernel.nix
+++ b/overlays/vendor-kernel.nix
@@ -67,83 +67,83 @@ in
 final: prev:
 prev.lib.mergeAttrsList (
   builtins.concatLists [
-    (mkLinuxFor prev "6_18_34" [
+    (mkLinuxFor final "6_18_34" [
       "02"
       "3"
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_18_33" [
+    (mkLinuxFor final "6_18_33" [
       "02"
       "3"
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_12_87" [
+    (mkLinuxFor final "6_12_87" [
       "02"
       "3"
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_12_85" [
+    (mkLinuxFor final "6_12_85" [
       "02"
       "3"
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_12_75" [
+    (mkLinuxFor final "6_12_75" [
       "02"
       "3"
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_12_47" [
+    (mkLinuxFor final "6_12_47" [
       "02"
       "3"
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_12_44" [
+    (mkLinuxFor final "6_12_44" [
       "02"
       "3"
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_12_34" [
+    (mkLinuxFor final "6_12_34" [
       "02"
       "3"
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_12_25" [
+    (mkLinuxFor final "6_12_25" [
       "02"
       "3"
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_6_74" [
+    (mkLinuxFor final "6_6_74" [
       "02"
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_6_51" [
+    (mkLinuxFor final "6_6_51" [
       "02"
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_6_31" [
+    (mkLinuxFor final "6_6_31" [
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_6_28" [
+    (mkLinuxFor final "6_6_28" [
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_1_73" [
+    (mkLinuxFor final "6_1_73" [
       "4"
       "5"
     ])
-    (mkLinuxFor prev "6_1_63" [
+    (mkLinuxFor final "6_1_63" [
       "4"
       "5"
     ])

--- a/pkgs/pisugar-power-manager-rs.nix
+++ b/pkgs/pisugar-power-manager-rs.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "pisugar-power-manager-rs";
-  version = "2.0.0";
+  version = "2.3.3";
 
   src = fetchFromGitHub {
     owner = "PiSugar";
     repo = "pisugar-power-manager-rs";
     rev = "v${version}";
-    sha256 = "sha256-OZ8yEFXEWlqEImjP7n08SjhX7atWnxb3I0jxD/E3FGg";
+    sha256 = "sha256-UmiaSQhIIIZawJH+O3Sc4bS5Jr4zayJMSdJeoUhBS5w=";
   };
 
-  cargoHash = "sha256-EHwlv6XlsltpaSBTKebhrgJYq3GTtB0t5tyNhkiptb8";
+  cargoHash = "sha256-8wp1RxeoAmPk8sMUy2UY+t0RhO/bpK2e322bmoA5ac4=";
 
   postPatch = ''
     sed -e 's#.*replace-with.*##' -i .cargo/config.toml

--- a/pkgs/raspberrypi/raspberrypi-utils.nix
+++ b/pkgs/raspberrypi/raspberrypi-utils.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "raspberrypi-utils";
-  version = "0-unstable-2026-07-08";
+  version = "0-unstable-2026-07-24";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "utils";
-    rev = "5edd399260b5081f9c1c96fc7f369b920d6732d1";
-    hash = "sha256-qxwASdmEH47oCjuPtboWuUkcNsw5j6eCSsWrNejpIMU=";
+    rev = "292dbe7e35296e556d839a0b9ae2ca957ac8c961";
+    hash = "sha256-8F4dJDsYqiJWBYqfVHKPpYgATQQM5QohcxhtJ7EQH3o=";
   };
 
   buildInputs = [

--- a/pkgs/raspberrypi/raspberrypi-utils.nix
+++ b/pkgs/raspberrypi/raspberrypi-utils.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "raspberrypi-utils";
-  version = "0-unstable-2026-06-23";
+  version = "0-unstable-2026-07-08";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "utils";
-    rev = "a30e7c7b227d9a5e6dbedc1d343077be7ad92959";
-    hash = "sha256-ayGsH9noSrmZQ99sQ1U/wYS6l7N5LWlr2xSvuoIw/qk=";
+    rev = "5edd399260b5081f9c1c96fc7f369b920d6732d1";
+    hash = "sha256-qxwASdmEH47oCjuPtboWuUkcNsw5j6eCSsWrNejpIMU=";
   };
 
   buildInputs = [


### PR DESCRIPTION
**Full Changelog**: https://github.com/nvmd/nixos-raspberrypi/compare/v1.20260707.1...455f1d8

### nixpkgs

* **flake: nixos-26.05** (e9d8a1c) by @nvmd - the pinned `nixpkgs` input moves from the `nixos-25.11` to the `nixos-26.05` release branch.
* **Fix NixOS 26.05 builds** (#212) by @cniry - installer configurations now force `networking.wireless.enable = false`. NixOS 26.05 enables the legacy `wpa_supplicant` path via NetworkManager, which conflicted with nixos-images' `iwd`-based installer Wi-Fi module and broke the installer builds.

### Overlays

* **use "final" for kernel overlays to enable cross compilation** (#214) by @avieth - the vendor kernel overlays take their inputs from `final` rather than `prev`, so kernel derivations follow the configured build platform. Fixes `required system or feature not available` when building the aarch64 kernel packages from an x86_64 host.

### Modules

* **configtxt: use lib.mkDefault for audio dtparam** (#228) by @epicrazzmatazz - the `audio` dtparam (`dtparam=audio=on`) is defined with `lib.mkDefault`, so it can be overridden or disabled from another module without an option definition conflict.

### Vendor packages

* **raspberrypi-utils 2026-07-24** (#219, #227) by @nvmd - two automated `nix-update` runs, from 2026-06-23 via 2026-07-08.
* **pisugar-power-manager-rs 2.3.3** (#207) by @nvmd - automated `nix-update` run, up from 2.0.0.

### CI, tooling & repo hygiene

* Dependabot GitHub Actions bumps by @nvmd:
  * `actions/checkout` → 7.0.1 (#224)
  * `DeterminateSystems/determinate-nix-action` → 3.21.8 (#225).

### Routine

* `flake.lock` updates by @nvmd, `github-actions[bot]` in #218, #222, #226, b147cc9

## Migration notes

* **Users — pinned `nixpkgs` moved to `nixos-26.05`.** Configurations that take `nixpkgs` from this flake (i.e. do not override the `nixpkgs` input or pass `nixpkgs` to `lib.nixosSystem`) move from the 25.11 to the 26.05 release branch. Review the [NixOS 26.05 release notes](https://nixos.org/manual/nixos/stable/release-notes) for incompatible changes, and make sure `system.stateVersion` is set explicitly.
* The kernel and firmware bundle is unchanged in this release: kernel `6.18.34`, firmware `1.20260521`.

## New Contributors
* @cniry made their first contribution in https://github.com/nvmd/nixos-raspberrypi/pull/212
* @avieth made their first contribution in https://github.com/nvmd/nixos-raspberrypi/pull/214
* @epicrazzmatazz made their first contribution in https://github.com/nvmd/nixos-raspberrypi/pull/228
