### PR TITLE
raspberrypi: add enable option guards

### DIFF
--- a/modules/raspberrypi.nix
+++ b/modules/raspberrypi.nix
@@ -5,6 +5,9 @@
   ...
 }:
 
+let
+  cfg = config.hardware.raspberry-pi;
+in
 {
   imports = [
     ./system/boot/loader/raspberrypi
@@ -13,55 +16,72 @@
     # config.txt is in `config.hardware.raspberry-pi.config-generated`
     ./configtxt-config.nix
   ];
-
-  boot.loader.raspberry-pi = {
-    enable = true;
+  options = {
+    hardware.raspberry-pi.appendKernelParams = lib.mkOption {
+      default = true;
+      description = "Whether to add /dev/serial0 and /dev/tty1 as consoles in kernel commandline. You may want to disable this when /dev/serial0 is missing or when /dev/tty1 is not desired as a kernel console.";
+    };
+    hardware.raspberry-pi.appendKernelModulesInitrd = lib.mkOption {
+      default = true;
+      description = "Whether to include some kernel modules specific to Raspberry Pi hardware in the initramfs (`boot.initrd.availableKernelModules`).";
+    };
+    hardware.raspberry-pi.addRaspberryPiUtils = lib.mkOption {
+      default = true;
+      description = "Whether to add `raspberrypi-utils` to `environment.systemPackages`.";
+    };
   };
-
-  hardware.raspberry-pi.config.all.options = {
-    arm_64bit = {
-      enable = true;
-      value = true;
-    };
-    enable_uart = {
-      enable = true;
-      value = true;
-    };
-    avoid_warnings = {
+  config = {
+    boot.loader.raspberry-pi = {
       enable = lib.mkDefault true;
-      value = lib.mkDefault true;
     };
+    hardware.raspberry-pi.config.all.options = {
+      arm_64bit = {
+        enable = lib.mkDefault true;
+        value = lib.mkDefault true;
+      };
+      enable_uart = {
+        enable = lib.mkDefault true;
+        value = lib.mkDefault true;
+      };
+      avoid_warnings = {
+        enable = lib.mkDefault true;
+        value = lib.mkDefault true;
+      };
+    };
+
+    boot.consoleLogLevel = lib.mkDefault 7;
+    # https://github.com/raspberrypi/firmware/issues/1539#issuecomment-784498108
+    # https://github.com/RPi-Distro/pi-gen/blob/master/stage1/00-boot-files/files/cmdline.txt
+    boot.kernelParams = lib.mkIf cfg.appendKernelParams [
+      "console=serial0,115200n8"
+      "console=tty1"
+    ];
+
+    boot.initrd.availableKernelModules = lib.mkIf cfg.appendKernelModulesInitrd [
+      "xhci_pci"
+      # https://github.com/NixOS/nixos-hardware/issues/631#issuecomment-1584100732
+      "usbhid"
+      "usb_storage"
+      "vc4"
+      "pcie_brcmstb" # required for the pcie bus to work
+      "reset-raspberrypi" # required for vl805 firmware to load
+    ];
+    hardware.enableRedistributableFirmware = lib.mkDefault true;
+
+    environment.systemPackages = lib.mkIf cfg.addRaspberryPiUtils (
+      with pkgs;
+      [
+        raspberrypi-utils
+      ]
+    );
+
+    # workaround for "modprobe: FATAL: Module <module name> not found"
+    # see https://github.com/NixOS/nixpkgs/issues/154163,
+    #     https://github.com/NixOS/nixpkgs/issues/154163#issuecomment-1350599022
+    nixpkgs.overlays = [
+      (final: super: {
+        makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
+      })
+    ];
   };
-
-  boot.consoleLogLevel = lib.mkDefault 7;
-  # https://github.com/raspberrypi/firmware/issues/1539#issuecomment-784498108
-  # https://github.com/RPi-Distro/pi-gen/blob/master/stage1/00-boot-files/files/cmdline.txt
-  boot.kernelParams = [
-    "console=serial0,115200n8"
-    "console=tty1"
-  ];
-
-  boot.initrd.availableKernelModules = [
-    "xhci_pci"
-    # https://github.com/NixOS/nixos-hardware/issues/631#issuecomment-1584100732
-    "usbhid"
-    "usb_storage"
-    "vc4"
-    "pcie_brcmstb" # required for the pcie bus to work
-    "reset-raspberrypi" # required for vl805 firmware to load
-  ];
-  hardware.enableRedistributableFirmware = true;
-
-  environment.systemPackages = with pkgs; [
-    raspberrypi-utils
-  ];
-
-  # workaround for "modprobe: FATAL: Module <module name> not found"
-  # see https://github.com/NixOS/nixpkgs/issues/154163,
-  #     https://github.com/NixOS/nixpkgs/issues/154163#issuecomment-1350599022
-  nixpkgs.overlays = [
-    (final: super: {
-      makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
-    })
-  ];
 }


### PR DESCRIPTION
Similar to 43622ed but for raspberrypi.nix. Useful e.g. when /dev/tty1 should not be a kernel console.

Additionally changed all option settings to use lib.mkDefault in case a user specifies them in their own configuration.