### PR TITLE
kernel 6.18.42

### DIFF
--- a/overlays/firmware-sources.nix
+++ b/overlays/firmware-sources.nix
@@ -3,6 +3,13 @@
 [
   {
     # this release is untagged in the upstream
+    # matches unstable kernel `raspberrypi/linux` 6.18.42
+    version = "0-unstable-20260806";
+    rev = "2cfe163628eb33eed11c97bfe3fb8169755d7e7a";
+    srcHash = "sha256-f/bqt0G56T/evXKbJiUf6+MWzytGhuJp9ZKPfiQKROQ=";
+  }
+  {
+    # this release is untagged in the upstream
     # matches stable kernel `raspberrypi/linux` 6.18.39
     # (from https://github.com/raspberrypi/linux/releases/tag/stable_20260724)
     # see `extra/git_hash`

--- a/overlays/linux-and-firmware.nix
+++ b/overlays/linux-and-firmware.nix
@@ -46,9 +46,14 @@ final: prev: {
 
   linuxAndFirmware = prev.lib.mergeAttrsList [
 
-    { default = final.linuxAndFirmware.v6_18_39; }
+    { default = final.linuxAndFirmware.v6_18_42; }
 
-    { latest = final.linuxAndFirmware.v6_18_39; }
+    { latest = final.linuxAndFirmware.v6_18_42; }
+
+    (mkBundle final "v6_18_42" {
+      fw = final.raspberrypifw_20260724;
+      wFw = final.raspberrypiWirelessFirmware_20260321;
+    })
 
     (mkBundle final "v6_18_39" {
       fw = final.raspberrypifw_20260724;

--- a/overlays/linux-and-firmware.nix
+++ b/overlays/linux-and-firmware.nix
@@ -51,7 +51,7 @@ final: prev: {
     { latest = final.linuxAndFirmware.v6_18_42; }
 
     (mkBundle final "v6_18_42" {
-      fw = final.raspberrypifw_20260724;
+      fw = final.raspberrypifw_20260806;
       wFw = final.raspberrypiWirelessFirmware_20260321;
     })
 

--- a/overlays/vendor-kernel.nix
+++ b/overlays/vendor-kernel.nix
@@ -67,6 +67,12 @@ in
 final: prev:
 prev.lib.mergeAttrsList (
   builtins.concatLists [
+    (mkLinuxFor final "6_18_42" [
+      "02"
+      "3"
+      "4"
+      "5"
+    ])
     (mkLinuxFor final "6_18_39" [
       "02"
       "3"

--- a/pkgs/linux-rpi/kernels.nix
+++ b/pkgs/linux-rpi/kernels.nix
@@ -23,6 +23,7 @@ let
 
 in
 listToAttrsWLVer [
+  linux.v6_18_42
   linux.v6_18_39
   linux.v6_18_34
   linux.v6_18_33

--- a/pkgs/linux-rpi/linux-sources.nix
+++ b/pkgs/linux-rpi/linux-sources.nix
@@ -1,5 +1,11 @@
 [
   {
+    modDirVersion = "6.18.42";
+    tag = "unstable_20260806";
+    rev = "8c0da7c3bb97a2e0aaa0d405d3052786c1469b35";
+    srcHash = "sha256-CMjVylJFgiX9TRQ+drFr/OicaKp0W7r0idIKdMSIuGA=";
+  }
+  {
     # https://github.com/raspberrypi/linux/releases/tag/stable_20260724
     modDirVersion = "6.18.39";
     tag = "stable_20260724";


### PR DESCRIPTION
This version includes a fix for [OVSwrap (CVE-2026-64531)](https://heyitsas.im/posts/ovswrap/)

I tested that the kernel builds and boots successfully on a pi 5