### PR TITLE
linux: address stdenv.isAarch64 deprecation warning

### DIFF
--- a/pkgs/linux-rpi/package.nix
+++ b/pkgs/linux-rpi/package.nix
@@ -106,7 +106,7 @@ in
 
     postFixup =
       let
-        armArch = if stdenv.isAarch64 then "arm64" else "arm";
+        armArch = if stdenv.hostPlatform.isAarch64 then "arm64" else "arm";
       in
       ''
         # Provide README together with overlays just like `raspberrypifw`


### PR DESCRIPTION
was getting

```
evaluation warning: stdenv.isAarch64 is deprecated, use stdenv.hostPlatform.isAarch64 instead
```